### PR TITLE
feat: process links

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -7,7 +7,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
 #   kernelspec:
-#     display_name: .venv
+#     display_name: flodym
 #     language: python
 #     name: python3
 # ---
@@ -58,9 +58,7 @@ time = Dimension(name="Time", letter="t", items=list(range(1980, 2011)))
 elements = Dimension(
     name="Elements",
     letter="e",
-    items=[
-        "single material",
-    ],
+    items=["single material"],
 )
 dimensions = DimensionSet(dim_list=[time, elements])
 
@@ -116,9 +114,8 @@ flows = make_empty_flows(processes=processes, flow_definitions=flow_definitions,
 # %%
 class SimpleMFA(MFASystem):
     def compute(self):
-        self.flows["sysenv => process 1"][...] = self.parameters[
-            "D"
-        ]  # the elipsis slice [...] ensures the dimensionality of the flow is not changed
+        # the elipsis slice [...] ensures the dimensionality of the flow is not changed
+        self.flows["sysenv => process 1"][...] = self.parameters["D"]
         self.flows["process 1 => process 2"][...] = (
             1 / (1 - self.parameters["alpha"]) * self.parameters["D"]
         )

--- a/examples/example2.ipynb
+++ b/examples/example2.ipynb
@@ -57,6 +57,7 @@
     "    ParameterDefinition,\n",
     "    FlowDefinition,\n",
     "    StockDefinition,\n",
+    "    ProcessDefinition,\n",
     "    MFASystem,\n",
     "    SimpleFlowDrivenStock,\n",
     ")\n",
@@ -108,12 +109,12 @@
    "outputs": [],
    "source": [
     "process_names = [\n",
-    "    \"sysenv\",\n",
-    "    \"shredder\",\n",
-    "    \"demolition\",\n",
-    "    \"remelting\",\n",
-    "    \"landfills\",\n",
-    "    \"slag piles\",\n",
+    "    ProcessDefinition(id=0, name=\"sysenv\"),\n",
+    "    ProcessDefinition(id=1, name=\"shredder\"),\n",
+    "    ProcessDefinition(id=2, name=\"demolition\"),\n",
+    "    ProcessDefinition(id=3, name=\"remelting\"),\n",
+    "    ProcessDefinition(id=4, name=\"landfills\"),\n",
+    "    ProcessDefinition(id=5, name=\"slag piles\"),\n",
     "]"
    ]
   },
@@ -307,7 +308,7 @@
     "    array=remelted,\n",
     "    intra_line_dim=\"Time\",\n",
     "    linecolor_dim=\"Material\",\n",
-    "    title=\"GDP-per-capita\",\n",
+    "    title=\"Total remelted material\",\n",
     ")\n",
     "fig = plotter.plot(do_show=True)"
    ]

--- a/examples/example2.ipynb
+++ b/examples/example2.ipynb
@@ -275,6 +275,7 @@
     "    dimension_sheets={d.name: d.name for d in dimension_definitions},\n",
     "    parameter_sheets={p.name: p.name for p in parameter_definitions},\n",
     ")\n",
+    "\n",
     "mfa_example.compute()"
    ]
   },
@@ -457,7 +458,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "flodym",
    "language": "python",
    "name": "python3"
   },

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -7,7 +7,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
 #   kernelspec:
-#     display_name: .venv
+#     display_name: flodym
 #     language: python
 #     name: python3
 # ---
@@ -207,6 +207,7 @@ mfa_example = SimpleMFA.from_excel(
     dimension_sheets={d.name: d.name for d in dimension_definitions},
     parameter_sheets={p.name: p.name for p in parameter_definitions},
 )
+
 mfa_example.compute()
 
 # %% [markdown]

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -53,6 +53,7 @@ from flodym import (
     ParameterDefinition,
     FlowDefinition,
     StockDefinition,
+    ProcessDefinition,
     MFASystem,
     SimpleFlowDrivenStock,
 )
@@ -85,12 +86,12 @@ parameter_definitions = [
 
 # %%
 process_names = [
-    "sysenv",
-    "shredder",
-    "demolition",
-    "remelting",
-    "landfills",
-    "slag piles",
+    ProcessDefinition(id=0, name="sysenv"),
+    ProcessDefinition(id=1, name="shredder"),
+    ProcessDefinition(id=2, name="demolition"),
+    ProcessDefinition(id=3, name="remelting"),
+    ProcessDefinition(id=4, name="landfills"),
+    ProcessDefinition(id=5, name="slag piles"),
 ]
 
 # %%
@@ -225,7 +226,7 @@ plotter = PlotlyArrayPlotter(
     array=remelted,
     intra_line_dim="Time",
     linecolor_dim="Material",
-    title="GDP-per-capita",
+    title="Total remelted material",
 )
 fig = plotter.plot(do_show=True)
 

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -7,7 +7,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
 #   kernelspec:
-#     display_name: .venv
+#     display_name: flodym
 #     language: python
 #     name: python3
 # ---

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -7,7 +7,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
 #   kernelspec:
-#     display_name: .venv
+#     display_name: flodym
 #     language: python
 #     name: python3
 # ---

--- a/flodym/__init__.py
+++ b/flodym/__init__.py
@@ -4,6 +4,7 @@ from flodym.mfa_definition import (
     DimensionDefinition as DimensionDefinition,
     StockDefinition as StockDefinition,
     ParameterDefinition as ParameterDefinition,
+    ProcessDefinition as ProcessDefinition,
 )
 from flodym.mfa_system import MFASystem as MFASystem
 from flodym.dimensions import DimensionSet as DimensionSet, Dimension as Dimension
@@ -13,13 +14,19 @@ from flodym.flodym_arrays import (
     StockArray as StockArray,
     Flow as Flow,
 )
-from flodym.processes import Process as Process, make_processes as make_processes
+from flodym.processes import (
+    Process as Process,
+    make_processes as make_processes,
+    set_process_parameters as set_process_parameters,
+    UnderdeterminedError as UnderdeterminedError,
+)
 from flodym.stocks import (
     Stock as Stock,
     SimpleFlowDrivenStock as SimpleFlowDrivenStock,
     DynamicStockModel as DynamicStockModel,
     InflowDrivenDSM as InflowDrivenDSM,
     StockDrivenDSM as StockDrivenDSM,
+    FlexibleDSM as FlexibleDSM,
 )
 from flodym.lifetime_models import (
     LifetimeModel as LifetimeModel,
@@ -41,3 +48,12 @@ from flodym.data_reader import (
     ExcelParameterReader as ExcelParameterReader,
     CompoundDataReader as CompoundDataReader,
 )
+from flodym.config import config as config
+
+Flow.model_rebuild()
+Stock.model_rebuild()
+SimpleFlowDrivenStock.model_rebuild()
+DynamicStockModel.model_rebuild()
+InflowDrivenDSM.model_rebuild()
+StockDrivenDSM.model_rebuild()
+FlexibleDSM.model_rebuild()

--- a/flodym/__init__.py
+++ b/flodym/__init__.py
@@ -4,6 +4,7 @@ from flodym.mfa_definition import (
     DimensionDefinition as DimensionDefinition,
     StockDefinition as StockDefinition,
     ParameterDefinition as ParameterDefinition,
+    ProcessDefinition as ProcessDefinition,
 )
 from flodym.mfa_system import MFASystem as MFASystem
 from flodym.dimensions import DimensionSet as DimensionSet, Dimension as Dimension
@@ -41,3 +42,11 @@ from flodym.data_reader import (
     ExcelParameterReader as ExcelParameterReader,
     CompoundDataReader as CompoundDataReader,
 )
+
+Flow.model_rebuild()
+Stock.model_rebuild()
+SimpleFlowDrivenStock.model_rebuild()
+DynamicStockModel.model_rebuild()
+InflowDrivenDSM.model_rebuild()
+StockDrivenDSM.model_rebuild()
+FlexibleDSM.model_rebuild()

--- a/flodym/__init__.py
+++ b/flodym/__init__.py
@@ -20,6 +20,7 @@ from flodym.stocks import (
     DynamicStockModel as DynamicStockModel,
     InflowDrivenDSM as InflowDrivenDSM,
     StockDrivenDSM as StockDrivenDSM,
+    FlexibleDSM as FlexibleDSM,
 )
 from flodym.lifetime_models import (
     LifetimeModel as LifetimeModel,

--- a/flodym/config.py
+++ b/flodym/config.py
@@ -1,0 +1,87 @@
+from pydantic import BaseModel, confloat
+from typing import Optional
+from enum import Enum
+import logging
+
+
+class ErrorBehavior(str, Enum):
+    ERROR = "error"
+    WARN = "warn"
+    INFO = "info"
+    IGNORE = "ignore"
+
+
+def handle_error(behavior: ErrorBehavior, message: str=None, error: Exception = None):
+
+    # ensures valid ErrorBehavior
+    behavior = ErrorBehavior(behavior)
+
+    if message is None == error is None:
+        raise ValueError("Exactly one of message or error must be provided.")
+
+    if behavior == ErrorBehavior.ERROR:
+        raise error or ValueError(message)
+    elif behavior == ErrorBehavior.WARN:
+        logging.warning(message or str(error))
+    elif behavior == ErrorBehavior.INFO:
+        logging.info(message or str(error))
+    elif behavior == ErrorBehavior.IGNORE:
+        pass
+
+
+class Checks(BaseModel, validate_assignment=True):
+    """
+    Which checks to perform during computation.
+    """
+
+    mass_balance_processes: bool = True
+    """Whether to check mass balance after each `process.compute()` call."""
+    mass_balance_stocks: bool = True
+    """Whether to check mass balance after each `stock.compute()` call."""
+    process_shares: bool = True
+    """Whether to check if unused shares are fulfilled after each `process.compute()` call.
+    Includes checking dimension splitter"""
+
+
+class ErrorBehaviors(BaseModel, validate_assignment=True):
+    """
+    What to do if a check fails.
+    """
+
+    mass_balance: ErrorBehavior = ErrorBehavior.ERROR
+    """what to do if mass balance is not satisfied."""
+    process_underdetermined: ErrorBehavior = ErrorBehavior.ERROR
+    """What to do if a process is underdetermined.
+    Does not apply to recursive mode and `MFASystem.compute_all_possible()`.
+    """
+    process_shares: ErrorBehavior = ErrorBehavior.WARN
+    """What to do if process shares are not fulfilled."""
+    unused_dimension_splitter: ErrorBehavior = ErrorBehavior.WARN
+    """What to do if a dimension splitter is not used in a process"""
+    check_flows: ErrorBehavior = ErrorBehavior.WARN
+    """What to do if a flow has negative or NaN value."""
+
+
+class Config(BaseModel, validate_assignment=True):
+    """
+    Configuration class for Flodym.
+    """
+
+    checks: Checks = Checks()
+    """Which checks to perform during computation."""
+
+    error_behaviors: ErrorBehaviors = ErrorBehaviors()
+    """What to do if a check fails."""
+
+    relative_tolerance: Optional[confloat(ge=0)] = 10.
+    """Tolerance relative to a float precision metric used for mass balance and other checks.
+    Increase if your mass balance checks fail due to rounding errors.
+    Overridden by `absolute_tolerance` if set.
+    """
+    absolute_tolerance: Optional[confloat(ge=0)] = None
+    """Absolute tolerance used for mass balance and other checks.
+    Overrides `relative_tolerance` if set.
+    If None, `relative_tolerance` is used.
+    """
+
+config = Config()

--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -7,6 +7,7 @@ import pandas as pd
 from .mfa_definition import DimensionDefinition
 
 
+
 class Dimension(PydanticBaseModel):
     """One of multiple dimensions over which MFA arrays are defined.
 
@@ -195,11 +196,6 @@ class DimensionSet(PydanticBaseModel):
         """shape of the array that would be created with the dimensions in the set"""
         return tuple(self.size(dim) for dim in self.letters)
 
-    @property
-    def ndim(self):
-        """the number of dimensions in the set"""
-        return len(self.dim_list)
-
     def get_subset(self, dims: tuple = None) -> "DimensionSet":
         """Selects :py:class:`Dimension` objects from the object attribute dim_list,
         according to the dims passed, which can be either letters or names.
@@ -273,6 +269,10 @@ class DimensionSet(PydanticBaseModel):
         intersection_letters = [dim.letter for dim in self.dim_list if dim.letter in other.letters]
         return self.get_subset(intersection_letters)
 
+    def __and__(self, other: "DimensionSet") -> "DimensionSet":
+        """Intersection operator for two DimensionSets."""
+        return self.intersect_with(other)
+
     def union_with(self, other: "DimensionSet") -> "DimensionSet":
         """Get the union of two DimensionSets.
 
@@ -284,6 +284,10 @@ class DimensionSet(PydanticBaseModel):
         """
         added_dims = [dim for dim in other.dim_list if dim.letter not in self.letters]
         return self.expand_by(added_dims)
+
+    def __or__(self, other: "DimensionSet") -> "DimensionSet":
+        """Union operator for two DimensionSets."""
+        return self.union_with(other)
 
     def difference_with(self, other: "DimensionSet") -> "DimensionSet":
         """Get the set difference of two DimensionSets.
@@ -298,6 +302,27 @@ class DimensionSet(PydanticBaseModel):
             dim.letter for dim in self.dim_list if dim.letter not in other.letters
         ]
         return self.get_subset(difference_letters)
+
+    def __sub__(self, other: "DimensionSet") -> "DimensionSet":
+        """Difference operator for two DimensionSets."""
+        return self.difference_with(other)
+
+    def __xor__(self, other: "DimensionSet") -> "DimensionSet":
+        """Symmetric difference operator for two DimensionSets."""
+        return (self - other) | (other - self)
+
+    @property
+    def ndim(self):
+        """the number of dimensions in the set"""
+        return len(self.dim_list)
+
+    def __len__(self) -> int:
+        """Return the number of dimensions in the set."""
+        return len(self.dim_list)
+
+    def __bool__(self) -> bool:
+        """Return True if the set is not empty."""
+        return len(self.dim_list) > 0
 
     @property
     def names(self):

--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -195,11 +195,6 @@ class DimensionSet(PydanticBaseModel):
         """shape of the array that would be created with the dimensions in the set"""
         return tuple(self.size(dim) for dim in self.letters)
 
-    @property
-    def ndim(self):
-        """the number of dimensions in the set"""
-        return len(self.dim_list)
-
     def get_subset(self, dims: tuple = None) -> "DimensionSet":
         """Selects :py:class:`Dimension` objects from the object attribute dim_list,
         according to the dims passed, which can be either letters or names.
@@ -273,6 +268,10 @@ class DimensionSet(PydanticBaseModel):
         intersection_letters = [dim.letter for dim in self.dim_list if dim.letter in other.letters]
         return self.get_subset(intersection_letters)
 
+    def __and__(self, other: "DimensionSet") -> "DimensionSet":
+        """Intersection operator for two DimensionSets."""
+        return self.intersect_with(other)
+
     def union_with(self, other: "DimensionSet") -> "DimensionSet":
         """Get the union of two DimensionSets.
 
@@ -284,6 +283,10 @@ class DimensionSet(PydanticBaseModel):
         """
         added_dims = [dim for dim in other.dim_list if dim.letter not in self.letters]
         return self.expand_by(added_dims)
+
+    def __or__(self, other: "DimensionSet") -> "DimensionSet":
+        """Union operator for two DimensionSets."""
+        return self.union_with(other)
 
     def difference_with(self, other: "DimensionSet") -> "DimensionSet":
         """Get the set difference of two DimensionSets.
@@ -298,6 +301,27 @@ class DimensionSet(PydanticBaseModel):
             dim.letter for dim in self.dim_list if dim.letter not in other.letters
         ]
         return self.get_subset(difference_letters)
+
+    def __sub__(self, other: "DimensionSet") -> "DimensionSet":
+        """Difference operator for two DimensionSets."""
+        return self.difference_with(other)
+
+    def __xor__(self, other: "DimensionSet") -> "DimensionSet":
+        """Symmetric difference operator for two DimensionSets."""
+        return (self - other) | (other - self)
+
+    @property
+    def ndim(self):
+        """the number of dimensions in the set"""
+        return len(self.dim_list)
+
+    def __len__(self) -> int:
+        """Return the number of dimensions in the set."""
+        return len(self.dim_list)
+
+    def __bool__(self) -> bool:
+        """Return True if the set is not empty."""
+        return len(self.dim_list) > 0
 
     @property
     def names(self):

--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -7,7 +7,6 @@ import pandas as pd
 from .mfa_definition import DimensionDefinition
 
 
-
 class Dimension(PydanticBaseModel):
     """One of multiple dimensions over which MFA arrays are defined.
 

--- a/flodym/flodym_arrays.py
+++ b/flodym/flodym_arrays.py
@@ -14,7 +14,7 @@ from pydantic import (
     model_validator,
     ModelWrapValidatorHandler,
 )
-from typing import Optional, Union, Callable, Any
+from typing import Optional, Union, Callable, Any, Self
 from copy import copy
 
 from .processes import Process

--- a/flodym/flodym_arrays.py
+++ b/flodym/flodym_arrays.py
@@ -8,11 +8,13 @@ from copy import deepcopy
 from collections import defaultdict
 import numpy as np
 import pandas as pd
-from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator
-from typing import Optional, Union, Callable
+from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator, ModelWrapValidatorHandler
+from typing import Optional, Union, Callable, Any, TYPE_CHECKING
+from typing_extensions import Self
 from copy import copy
 
-from .processes import Process
+if TYPE_CHECKING:
+    from .processes import Process
 from .dimensions import DimensionSet, Dimension
 from ._df_to_flodym_array import DataFrameToFlodymDataConverter
 
@@ -61,6 +63,8 @@ class FlodymArray(PydanticBaseModel):
     """Values of the FlodymArray. Must have the same shape as the dimensions of the FlodymArray. If None, an array of zeros is created."""
     name: Optional[str] = "unnamed"
     """Name of the FlodymArray."""
+    _is_set: bool = False
+    """Flag indicating whether the flow has been set or not."""
 
     @model_validator(mode="after")
     def validate_values(self):
@@ -83,6 +87,14 @@ class FlodymArray(PydanticBaseModel):
                 f"Array shape: {self.dims.shape}\n"
                 f"Values shape: {self.values.shape}\n"
             )
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def mark_set_or_unset(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+        obj = handler(data)
+        if isinstance(data, dict):
+            obj._is_set = "values" in data
+        return obj
 
     @classmethod
     def from_dims_superset(
@@ -171,6 +183,7 @@ class FlodymArray(PydanticBaseModel):
             self._check_value_format()
         else:
             self.values[...] = values
+        self._is_set = True
 
     def sum_values(self):
         """Return the sum of all values in the FlodymArray."""
@@ -447,6 +460,7 @@ class FlodymArray(PydanticBaseModel):
         if isinstance(item, FlodymArray):
             slice_obj = self._sub_array_handler(keys)
             self.values[slice_obj.ids] = item.sum_values_to(slice_obj.dim_letters)
+            self._is_set = True
         else:
             self.set_values(copy(item))
         return
@@ -565,6 +579,26 @@ class FlodymArray(PydanticBaseModel):
             for i, letter in enumerate(self.dims.letters)
         ]
         return np.array(items).transpose()
+
+    @property
+    def is_set(self) -> bool:
+        """A boolean to indicate whether the flow's values are known or not."""
+        return self._is_set
+
+    def mark_set(self):
+        """Mark the flow as having values."""
+        self._is_set = True
+
+    def mark_unset(self):
+        """Mark the flow as not having values"""
+        self._is_set = False
+
+    @property
+    def _absolute_float_precision(self) -> float:
+        """The numpy float precision, multiplied by the maximum absolute flow or stock value."""
+        max_value = np.max(np.abs(self.values))
+        epsilon = np.finfo(self.values.dtype).eps
+        return epsilon * max_value
 
     def __str__(self):
         base = f"{self.__class__.__name__} '{self.name}'"
@@ -750,9 +784,9 @@ class Flow(FlodymArray):
 
     model_config = ConfigDict(protected_namespaces=())
 
-    from_process: Process
+    from_process: 'Process'
     """Process from which the flow originates."""
-    to_process: Process
+    to_process: 'Process'
     """Process to which the flow goes."""
 
     @property
@@ -764,6 +798,13 @@ class Flow(FlodymArray):
     def to_process_id(self):
         """ID of the process to which the flow goes."""
         return self.to_process.id
+
+    @model_validator(mode="after")
+    def attach_to_process(self):
+        """Add the flow to the from and to processes."""
+        self.from_process.add_outflow(self)
+        self.to_process.add_inflow(self)
+        return self
 
 
 class StockArray(FlodymArray):

--- a/flodym/flodym_arrays.py
+++ b/flodym/flodym_arrays.py
@@ -8,7 +8,12 @@ from copy import deepcopy
 from collections import defaultdict
 import numpy as np
 import pandas as pd
-from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator, ModelWrapValidatorHandler
+from pydantic import (
+    BaseModel as PydanticBaseModel,
+    ConfigDict,
+    model_validator,
+    ModelWrapValidatorHandler,
+)
 from typing import Optional, Union, Callable, Any
 from copy import copy
 

--- a/flodym/flodym_arrays.py
+++ b/flodym/flodym_arrays.py
@@ -781,9 +781,9 @@ class Flow(FlodymArray):
 
     model_config = ConfigDict(protected_namespaces=())
 
-    from_process: 'Process'
+    from_process: "Process"
     """Process from which the flow originates."""
-    to_process: 'Process'
+    to_process: "Process"
     """Process to which the flow goes."""
 
     @property

--- a/flodym/flow_helper.py
+++ b/flodym/flow_helper.py
@@ -26,11 +26,12 @@ def make_empty_flows(
     """
     flows = {}
     for flow_definition in flow_definitions:
-        try:
-            from_process = processes[flow_definition.from_process_name]
-            to_process = processes[flow_definition.to_process_name]
-        except KeyError:
-            raise KeyError(f"Missing process required by flow definition {flow_definition}.")
+        if flow_definition.from_process_name not in processes:
+            raise KeyError(f"Process name {flow_definition.from_process_name} given in flow definition is not found in processes.")
+        from_process = processes[flow_definition.from_process_name]
+        if flow_definition.to_process_name not in processes:
+            raise KeyError(f"Process name {flow_definition.to_process_name} given in flow definition is not found in processes.")
+        to_process = processes[flow_definition.to_process_name]
         if flow_definition.name_override is not None:
             name = flow_definition.name_override
         else:

--- a/flodym/flow_helper.py
+++ b/flodym/flow_helper.py
@@ -27,10 +27,14 @@ def make_empty_flows(
     flows = {}
     for flow_definition in flow_definitions:
         if flow_definition.from_process_name not in processes:
-            raise KeyError(f"Process name {flow_definition.from_process_name} given in flow definition is not found in processes.")
+            raise KeyError(
+                f"Process name {flow_definition.from_process_name} given in flow definition is not found in processes."
+            )
         from_process = processes[flow_definition.from_process_name]
         if flow_definition.to_process_name not in processes:
-            raise KeyError(f"Process name {flow_definition.to_process_name} given in flow definition is not found in processes.")
+            raise KeyError(
+                f"Process name {flow_definition.to_process_name} given in flow definition is not found in processes."
+            )
         to_process = processes[flow_definition.to_process_name]
         if flow_definition.name_override is not None:
             name = flow_definition.name_override

--- a/flodym/mfa_definition.py
+++ b/flodym/mfa_definition.py
@@ -126,6 +126,19 @@ class ParameterDefinition(DefinitionWithDimLetters):
     """Name of the parameter."""
 
 
+class ProcessDefinition(PydanticBaseModel):
+    id: int
+    """ID of the process."""
+    name: str
+    """Name of the process."""
+    inflow_shares: Optional[Dict[str, str]] = None
+    """parameter names to use as inflow shares, keyed by from_process name of inflow"""
+    outflow_shares: Optional[Dict[str, str]] = None
+    """parameter names to use as outflow shares, keyed by to_process name of outflow"""
+    dimension_splitter: Optional[str] = None
+    """Name of the parameter to use for splitting the total process flow into new dimensions."""
+
+
 class MFADefinition(PydanticBaseModel):
     """All the information needed to define an MFA system, compiled of lists of definition objects."""
 
@@ -133,7 +146,7 @@ class MFADefinition(PydanticBaseModel):
 
     dimensions: List[DimensionDefinition]
     """List of definitions of dimensions used in the model."""
-    processes: List[str]
+    processes: List[str|ProcessDefinition]
     """List of process names used in the model."""
     flows: List[FlowDefinition]
     """List of definitions of flows used in the model."""

--- a/flodym/mfa_definition.py
+++ b/flodym/mfa_definition.py
@@ -140,7 +140,7 @@ class MFADefinition(PydanticBaseModel):
 
     dimensions: List[DimensionDefinition]
     """List of definitions of dimensions used in the model."""
-    processes: List[str|ProcessDefinition]
+    processes: List[str | ProcessDefinition]
     """List of process names used in the model."""
     flows: List[FlowDefinition]
     """List of definitions of flows used in the model."""

--- a/flodym/mfa_definition.py
+++ b/flodym/mfa_definition.py
@@ -126,6 +126,13 @@ class ParameterDefinition(DefinitionWithDimLetters):
     """Name of the parameter."""
 
 
+class ProcessDefinition(PydanticBaseModel):
+    id: int
+    """ID of the process."""
+    name: str
+    """Name of the process."""
+
+
 class MFADefinition(PydanticBaseModel):
     """All the information needed to define an MFA system, compiled of lists of definition objects."""
 
@@ -133,7 +140,7 @@ class MFADefinition(PydanticBaseModel):
 
     dimensions: List[DimensionDefinition]
     """List of definitions of dimensions used in the model."""
-    processes: List[str]
+    processes: List[str|ProcessDefinition]
     """List of process names used in the model."""
     flows: List[FlowDefinition]
     """List of definitions of flows used in the model."""

--- a/flodym/mfa_system.py
+++ b/flodym/mfa_system.py
@@ -302,6 +302,15 @@ class MFASystem(PydanticBaseModel):
         if all_good:
             logging.info(f"Success - No negative flows or NaN values in {self.__class__.__name__}")
 
+    def mark_all_unset(self):
+        """Mark all parameters as unset."""
+        for flow in self.flows.values():
+            flow.mark_unset()
+        for stock in self.stocks.values():
+            stock.inflow.mark_unset()
+            stock.outflow.mark_unset()
+            stock.stock.mark_unset()
+
     @staticmethod
     def _error_or_warning(message: str, raise_error: bool) -> bool:
         if raise_error:

--- a/flodym/mfa_system.py
+++ b/flodym/mfa_system.py
@@ -13,7 +13,7 @@ from .mfa_definition import MFADefinition
 from .dimensions import DimensionSet
 from .flodym_arrays import Flow, Parameter, FlodymArray
 from .stocks import Stock
-from .processes import Process, make_processes
+from .processes import Process, make_processes, set_process_parameters
 from .stock_helper import make_empty_stocks
 from .flow_helper import make_empty_flows
 from .data_reader import (
@@ -24,6 +24,7 @@ from .data_reader import (
     ExcelDimensionReader,
     ExcelParameterReader,
 )
+from .config import config, ErrorBehavior, handle_error
 
 
 class MFASystem(PydanticBaseModel):
@@ -75,6 +76,8 @@ class MFASystem(PydanticBaseModel):
         stocks = make_empty_stocks(
             processes=processes, stock_definitions=definition.stocks, dims=dims
         )
+        set_process_parameters(processes, definition.processes, parameters)
+
         return cls(
             dims=dims,
             parameters=parameters,
@@ -180,86 +183,50 @@ class MFASystem(PydanticBaseModel):
         dims = self.dims.get_subset(dim_letters)
         return FlodymArray(dims=dims, **kwargs)
 
-    def _get_mass_balance(self) -> Dict[str, FlodymArray]:
-        """Calculate the mass balance for each process, by summing the contributions.
-        - all flows entering (positive)
-        - all flows leaving (negative)
-        - the stock change of the process (negative)
-
-        Returns:
-            A dictionary mapping process names to their mass balance contributions.
-            Each contribution is a :py:class:`flodym.FlodymArray` with dimensions common to all contributions.
-        """
-        contributions = {p: [] for p in self.processes.keys()}
-
-        # Add flows to mass balance
-        for flow in self.flows.values():
-            contributions[flow.from_process.name].append(-flow)  # Subtract flow from start process
-            contributions[flow.to_process.name].append(flow)  # Add flow to end process
-
-        # Add stock changes to the mass balance
-        for stock in self.stocks.values():
-            if stock.process is None:  # not connected to a process
-                continue
-            stock_change = stock.inflow - stock.outflow
-            #    sum(flows_to) - sum(flows_from) = stock_change
-            # => sum(flows_to) - sum(flows_from) - stock_change = 0
-            # => stock_change is subtracted from the process
-            contributions[stock.process.name].append(-stock_change)
-            # system_mass_change = sum(stock_changes),
-            # where the sysenv process mass balance is the negative system_mass_change:
-            # system_mass_change = flows_into_system - flows_out_of_system
-            #                    = sum(flows_from_sysenv) - sum(flows_to_sysenv)
-            # So stock change is accounted to sysenv process with opposite sign as to other
-            # processes => added instead of subtracted.
-            contributions["sysenv"].append(stock_change)
-
-        return {p_name: sum(parts) for p_name, parts in contributions.items()}
-
-    @property
-    def _absolute_float_precision(self) -> float:
-        """The numpy float precision, multiplied by the maximum absolute flow or stock value."""
-        max_flow_value = max([np.max(np.abs(f.values)) for f in self.flows.values()])
-        max_stock_value = max([np.max(np.abs(s.stock.values)) for s in self.stocks.values()])
-        epsilon = np.finfo(next(iter(self.flows.values())).values.dtype).eps
-        return epsilon * max(max_flow_value, max_stock_value)
-
-    def check_mass_balance(self, tolerance=None, raise_error: bool = True):
+    def check_mass_balance(self, error_behavior: ErrorBehavior = None):
         """Compute mass balance, and check whether it is within a certain tolerance.
         Throw an error if it isn't.
 
         Args:
-            tolerance (float, optional): The tolerance for the mass balance check.
-                If None, defaults to 100 times the numpy float precision,
-                multiplied by the maximum absolute flow or stock value.
-            raise_error (bool): If True, raises an error if the mass balance check fails.
-                Else, logs a warning and continues execution.
+            error_behavior (ErrorBehavior): What to do if the mass balance check fails.
+                If None, takes the global config setting, which defaults to raising an error.
         """
 
         logging.info(f"Checking mass balance of {self.__class__.__name__} object...")
 
-        if tolerance is None:
-            tolerance = 100 * self._absolute_float_precision
+        self.processes["sysenv"].check_mass_balance(tolerance=self.tolerance, error_behavior=error_behavior, mass_change_target=-self.total_stock_change,)
+        for process in self.processes.values():
+            process.check_mass_balance(tolerance=self.tolerance, error_behavior=error_behavior)
 
-        # returns array with dim [t, process, e]
-        balances = self._get_mass_balance()
-        max_errors = {p_name: np.max(np.abs(b.values)) for p_name, b in balances.items()}
-        failed = {p_name: e for p_name, e in max_errors.items() if e > tolerance}
-        if failed:
-            info = ", ".join(f"{p_name} (max error: {e})" for p_name, e in failed.items())
-            message = "Mass balance check failed for the following processes: " + info
-            self._error_or_warning(message, raise_error)
-        else:
-            logging.info(f"Success - Mass balance is consistent!")
+        for stock in self.stocks.values():
+            stock.check_mass_balance(tolerance=self.tolerance, error_behavior=error_behavior)
+
+    @property
+    def total_stock_change(self):
+        return sum(s.net_inflow for s in self.stocks.values() if s.process is not None)
+
+    @property
+    def _absolute_float_precision(self) -> float:
+        max_flows = max(f._absolute_float_precision for f in self.flows.values())
+        max_stocks = max(s.stock._absolute_float_precision for s in self.stocks.values())
+        return max(max_flows, max_stocks)
+
+    @property
+    def tolerance(self) -> float:
+        """Get the absolute tolerance for checks, based on the system's float precision."""
+        if config.absolute_tolerance is not None:
+            return config.absolute_tolerance
+        return config.relative_tolerance * self._absolute_float_precision
 
     def check_flows(
-        self, exceptions: list[str] = [], raise_error: bool = False, verbose: bool = False
+        self, exceptions: list[str] = [], error_behavior: ErrorBehavior = None, verbose: bool = False
     ):
         """Check if all flows are non-negative.
 
         Args:
             exceptions (list[str]): A list of strings representing flow names to be excluded from the check.
-            raise_error (bool): If True, raises an error instead of logging warnings.
+            error_behavior (ErrorBehavior): What to do if the mass balance check fails.
+                If None, takes the global config setting, which defaults to logging a warning.
             verbose (bool): If True, logs detailed information about negative flows.
 
         Raises:
@@ -270,6 +237,8 @@ class MFASystem(PydanticBaseModel):
             Info: If no negative flows are found.
         """
         logging.info("Checking flows for NaN and negative values...")
+        if error_behavior is None:
+            error_behavior = config.error_behaviors.check_flows
 
         flows = [f for f in self.flows.values() if f.name not in exceptions]
         flows = [
@@ -283,28 +252,33 @@ class MFASystem(PydanticBaseModel):
         for flow in flows:
             if np.any(np.isnan(flow.values)):
                 message = f"NaN values found in flow {flow.name}!"
-                self._error_or_warning(message, raise_error)
+                handle_error(behavior=error_behavior, message=message)
                 all_good = False
 
         # Check for negative values
-        tolerance = 100 * self._absolute_float_precision
         for flow in flows:
-            if np.any(flow.values < -tolerance):
+            if np.any(flow.values < -self.tolerance):
                 message = f"Negative value in flow {flow.name}!"
                 if verbose:
                     message += f"\n Items:"
-                    indices = flow.items_where(lambda x: x < -tolerance)
+                    indices = flow.items_where(lambda x: x < -self.tolerance)
                     for index in indices:
                         message += "\n  " + ", ".join(index)
-                self._error_or_warning(message, raise_error)
+                handle_error(behavior=error_behavior, message=message)
                 all_good = False
 
         if all_good:
             logging.info(f"Success - No negative flows or NaN values in {self.__class__.__name__}")
 
-    @staticmethod
-    def _error_or_warning(message: str, raise_error: bool) -> bool:
-        if raise_error:
-            raise ValueError(message)
-        else:
-            logging.warning(message)
+    def mark_all_unset(self):
+        """Mark all parameters as unset."""
+        for flow in self.flows.values():
+            flow.mark_unset()
+        for stock in self.stocks.values():
+            stock.inflow.mark_unset()
+            stock.outflow.mark_unset()
+            stock.stock.mark_unset()
+
+    def compute_all_possible(self):
+        for process in self.processes.values():
+            process.compute(on_underdetermined="info", recursive=True)

--- a/flodym/processes.py
+++ b/flodym/processes.py
@@ -5,6 +5,7 @@ from .flodym_arrays import Flow
 from .stocks import Stock
 from .mfa_definition import ProcessDefinition
 
+
 class Process(PydanticBaseModel, arbitrary_types_allowed=True):
     """Processes serve as nodes for the MFA system layout definition.
     Flows are defined between two processes. Stocks are connected to a process.
@@ -60,7 +61,9 @@ class Process(PydanticBaseModel, arbitrary_types_allowed=True):
         if from_process in self._inflows:
             del self._inflows[from_process]
         else:
-            raise ValueError(f"In process {self.name}: No inflow from process '{from_process}' found.")
+            raise ValueError(
+                f"In process {self.name}: No inflow from process '{from_process}' found."
+            )
 
     def remove_outflow(self, to_process: str) -> None:
         """Remove an outflow from the process."""
@@ -70,7 +73,7 @@ class Process(PydanticBaseModel, arbitrary_types_allowed=True):
             raise ValueError(f"In process {self.name}: No outflow to process '{to_process}' found.")
 
 
-def make_processes(definitions: List[str|ProcessDefinition]) -> dict[str, Process]:
+def make_processes(definitions: List[str | ProcessDefinition]) -> dict[str, Process]:
     """Create a dictionary of processes from a list of process names."""
     processes = {}
     for definition in definitions:
@@ -79,7 +82,9 @@ def make_processes(definitions: List[str|ProcessDefinition]) -> dict[str, Proces
             id = len(processes)
         elif isinstance(definition, ProcessDefinition):
             if definition.id != len(processes):
-                raise ValueError(f"Processes must be defined with consecutive IDs starting from 0, but found {definition.id} in {len(processes)}'th definition.")
+                raise ValueError(
+                    f"Processes must be defined with consecutive IDs starting from 0, but found {definition.id} in {len(processes)}'th definition."
+                )
             name = definition.name
             id = definition.id
         processes[name] = Process(name=name, id=id)

--- a/flodym/processes.py
+++ b/flodym/processes.py
@@ -1,9 +1,25 @@
-from typing import List
-
+from typing import List, Dict, Optional
 from pydantic import BaseModel as PydanticBaseModel, model_validator
+import logging
+from functools import reduce
+import numpy as np
+
+from .flodym_arrays import Flow, FlodymArray, Parameter
+from .stocks import Stock
+from .mfa_definition import ProcessDefinition
+from .dimensions import DimensionSet
+from .config import config, handle_error, ErrorBehavior
 
 
-class Process(PydanticBaseModel):
+class UnderdeterminedError(Exception):
+    """Exception raised when a process is underdetermined."""
+
+    def __init__(self, process: "Process", message: str):
+        message = f"Cannot compute process '{process.name}' with ID {process.id}, as it is underdetermined. \n" + message
+        super().__init__(message)
+        self.message = message
+
+class Process(PydanticBaseModel, arbitrary_types_allowed=True):
     """Processes serve as nodes for the MFA system layout definition.
     Flows are defined between two processes. Stocks are connected to a process.
     Processes do not contain values themselves.
@@ -17,6 +33,16 @@ class Process(PydanticBaseModel):
     """Name of the process."""
     id: int
     """ID of the process."""
+    _inflows: Dict[str, Flow] = {}
+    """Inflows to the process, keyed by linked process name."""
+    _outflows: Dict[str, Flow] = {}
+    """Outflows from the process, keyed by linked process name."""
+    dimension_splitter: Optional["FlodymArray"] = None
+    stock: Optional[Stock] = None
+    _inflow_shares: Dict[str, "FlodymArray"] = {}
+    _outflow_shares: Dict[str, "FlodymArray"] = {}
+    _total: FlodymArray = None
+    _was_overdetermined: bool = None
 
     @model_validator(mode="after")
     def check_id0(self):
@@ -27,7 +53,494 @@ class Process(PydanticBaseModel):
             )
         return self
 
+    def __repr__(self):
+        return ""  # TODO
 
-def make_processes(definitions: List[str]) -> dict[str, Process]:
+    @property
+    def inflows(self) -> Dict[str, Flow]:
+        """Inflows to the process."""
+        return self._inflows
+
+    @property
+    def outflows(self) -> Dict[str, Flow]:
+        """Outflows from the process."""
+        return self._outflows
+
+    def add_inflow(self, flow: Flow) -> None:
+        """Add an inflow flow to the process."""
+        self._inflows[flow.from_process.name] = flow
+
+    def add_outflow(self, flow: Flow) -> None:
+        """Add an outflow flow from the process."""
+        self._outflows[flow.to_process.name] = flow
+
+    def remove_inflow(self, from_process: str) -> None:
+        """Remove an inflow from the process."""
+        if from_process in self._inflows:
+            del self._inflows[from_process]
+        else:
+            raise ValueError(f"In process {self.name}: No inflow from process '{from_process}' found.")
+
+    def remove_outflow(self, to_process: str) -> None:
+        """Remove an outflow from the process."""
+        if to_process in self._outflows:
+            del self._outflows[to_process]
+        else:
+            raise ValueError(f"In process {self.name}: No outflow to process '{to_process}' found.")
+
+    def add_inflow_share(self, from_process: str, share: FlodymArray):
+        if from_process not in self._inflows:
+            raise ValueError(f"In process {self.name}: Cannot add inflow share from process {from_process}, as no such inflow found.")
+        self._inflow_shares[from_process] = share
+
+    def add_outflow_share(self, to_process: str, share: FlodymArray):
+        if to_process not in self._outflows:
+            raise ValueError(f"In process {self.name}: Cannot add outflow share to process {to_process}, as no such outflow found.")
+        self._outflow_shares[to_process] = share
+
+    def remove_inflow_share(self, from_process: str):
+        """Remove the inflow share for a given process."""
+        if from_process in self._inflow_shares:
+            del self._inflow_shares[from_process]
+        else:
+            raise ValueError(f"In process {self.name}: No inflow share for process '{from_process}' found.")
+
+    def remove_outflow_share(self, to_process: str):
+        """Remove the outflow share for a given process."""
+        if to_process in self._outflow_shares:
+            del self._outflow_shares[to_process]
+        else:
+            raise ValueError(f"In process {self.name}: No outflow share for process '{to_process}' found.")
+
+    @property
+    def is_computed(self) -> bool:
+        """Check if the process has been computed."""
+        if self.unknown_flows("in") or self.unknown_flows("out"):
+            return False
+        if self.stock is not None and not self.stock.is_computed:
+            return False
+        return True
+
+    def compute(self, on_underdetermined: ErrorBehavior = "error", recursive: bool=False) -> None:
+        """Compute all unknown flows of the process, based on topological information and known in/outflows.
+        This covers most cases of MFA processes, but not all.
+        Sometimes manual computations are still necessary.
+        For example, if there is a 2x2 equation system to solve (see example 1).
+
+        Topological information needed for this includes:
+        - the inflows and outflows
+        - the shares of some in- or outflows relative to the process total
+        - an array to multiply with to apply a dimension split
+
+        The computation assumes the following process structure:
+        - one or several inflows
+        - combined into a total
+        - possible dimension change
+        - one or several outflows
+        Though quite general, this applies some restrictions on the possible process layouts.
+        For example, no dimension expansion of individual in- or outflows through multiplication with shares is allowed.
+        However, this can be realized by adding an own process which only applies this dimension splitting.
+
+        The computation follows the following steps:
+        - Detect if the total can be calculated from either the known inflows and inflow shares (forward mode),
+          or from the known outflows and outflow shares (backward mode)
+          Let's assume forward mode in the following, but backward mode works in the same way.
+          The total can be calculated...
+          - If all inflows are given, the total is simply their sum.
+          - If a flow and its share are given, the total is that flow divided by its share
+          - If the shares of all unknown flows are given, the total is t = sum(known_flows) / (1 - sum(shares_of_unknown_flows))
+          If none of the three conditions is met on neither side (in/out), then the total cannot be calculated, and thus the whole
+          process cannot be calculated.
+        - Detect if there is a dimension_splitter and if it provides dimension information that the total does not have.
+          If this is the case, apply dimension splitter by multiplying the total with it
+        - Compute unknown flows. All but one unknown flows on each side need a share. Each of these unknown outflows with share
+          is then calculated as total * share. If there is one remaining unknown flow without share, it is calculated as
+          total - sum(known_flows_of_this_side).
+          If more than one unknown flow on one side has no share defined, it cannot be calculated, and thus the whole process cannot be calculated.
+        """
+        if self.is_computed:
+            logging.debug(f"Process {self.name} with ID {self.id} is already computed.")
+            return
+        if self.id == 0:
+            logging.debug(f"Process {self.name} with ID {self.id} is the system boundary and cannot be computed.")
+            return
+        try:
+
+            self._was_overdetermined = self.is_overdetermined
+            self.try_compute()
+
+            if not self.is_computed:
+                raise ValueError(
+                    f"In Process {self.name}: After computation, there are still unknown flows. "
+                    "This indicates an internal flodym error."
+                )
+
+            if config.checks.mass_balance_processes:
+                self.check_mass_balance()
+
+            if recursive:
+                for flow in self.inflows.values():
+                    flow.from_process.compute(on_underdetermined=on_underdetermined, recursive=True)
+                for flow in self.outflows.values():
+                    flow.to_process.compute(on_underdetermined=on_underdetermined, recursive=True)
+
+        except UnderdeterminedError as e:
+            if on_underdetermined is None:
+                on_underdetermined = config.error_behaviors.process_underdetermined
+            if on_underdetermined == ErrorBehavior.INFO:
+                # shorter message for readability in recursive mode (many will be underdertermined)
+                e.message = f"Process {self.name} is underdetermined. Skip computation."
+            handle_error(behavior=on_underdetermined, error=e)
+
+    def try_compute(self):
+        if self.stock is None:
+            self.compute_no_stock()
+        else:
+            self.stock.compute_process()
+
+    def compute_no_stock(self):
+        if self.name == "fabrication":
+            pass
+        self.compute_total()
+        self.apply_dimension_splitter()
+        self.compute_flows()
+        self.check_shares()
+
+    def flows(self, direction: str):
+        if direction == "in":
+            return self._inflows
+        elif direction == "out":
+            return self._outflows
+        else:
+            raise ValueError("Direction must be 'in' or 'out'.")
+
+    def shares(self, side: str):
+        if side == "in":
+            return self._inflow_shares
+        elif side == "out":
+            return self._outflow_shares
+        else:
+            raise ValueError("Direction must be 'in' or 'out'.")
+
+    def neither_known(self, side: str) -> List[str]:
+        return [
+            name for name, flow in self.flows(side).items() if not flow.is_set
+            and name not in self.shares(side)
+        ]
+
+    def known_flows(self, side: str) -> Dict[str, Flow]:
+        return {
+            name: flow for name, flow in self.flows(side).items() if flow.is_set
+        }
+
+    def unknown_flows(self, side: str) -> Dict[str, Flow]:
+        return {
+            name: flow for name, flow in self.flows(side).items() if not flow.is_set
+        }
+
+    def both_known(self, side: str) -> List[str]:
+        return [
+            name for name, flow in self.flows(side).items() if flow.is_set
+            and name in self.shares(side)
+        ]
+
+    @property
+    def is_overdetermined(self) -> bool:
+        n_degree_of_freedom = len(self.flows("in")) + len(self.flows("out")) + 1  # +1 for total
+        n_conditions = 2  # sum_inflows = total and sum_outflows = total
+        n_given = (len(self.known_flows("in")) + len(self.known_flows("out")) + len(self.shares("in")) + len(self.shares("out")))
+        return n_given > n_degree_of_freedom - n_conditions
+
+    def can_compute_total(self, from_side: str) -> bool:
+        """Check if the process can compute the total flow through the process in the given direction."""
+        return (self.both_known(from_side) or
+            (len(self.neither_known(from_side)) == 0 and len(self.known_flows(from_side)) >= 1))
+
+    def can_compute_flows(self, sides: List[str] = ["in", "out"]) -> bool:
+        """Check if the process can compute the flows in the given direction."""
+        return all(len(self.neither_known(side)) <= 1 for side in sides)
+
+    def compute_total(self, try_sides: List[str] = ["in", "out"]):
+        """Compute the total flow based on the inflows or outflows."""
+        side = None
+        for s in try_sides:
+            if self.can_compute_total(s):
+                side = s
+                break
+        if side is None:
+            message = self.get_underdetermined_error_message_total(try_sides)
+            raise UnderdeterminedError(process=self, message=message)
+
+        if len(self.known_flows(side)) == len(self.flows(side)):
+            # all flows are known
+            self._total = sum(self.flows(side).values())
+        elif self.both_known(side):
+            name = self.both_known(side)[0]
+            excess_dims = self.shares(side)[name].dims - self.flows(side)[name].dims
+            if excess_dims:
+                names = ", ".join(excess_dims.names)
+                raise ValueError(
+                    f"In Process {self.name}: Share of flow to/from process {name} has dimensions "
+                    f"{names} not contained in the flow's dimensions."
+                )
+            self._total = self.flows(side)[name] / self.shares(side)[name]
+        else:
+            sum_known = sum(self.known_flows(side).values())
+            shares_unknown = {name: self.shares(side)[name] for name in self.unknown_flows(side)}
+            dims_unknown = reduce(
+                lambda x, y: x | y.dims, shares_unknown.values(), DimensionSet(dim_list=[])
+            )
+            if dims_unknown - sum_known.dims:
+                share_names = ", ".join(
+                    [name for name, share in shares_unknown.items() if share.dims - sum_known.dims]
+                )
+                excess_names = ", ".join((dims_unknown-sum_known.dims).names)
+                raise ValueError(
+                    f"In Process {self.name}: Error when trying to infer total flow from known "
+                    f"flows and shares of unknown flows: Shares of flows to/from process(es) "
+                    f"{share_names} has dimensions " f"{excess_names} not contained in all the "
+                    f"known flows from/to processes {', '.join(self.known_flows(side))}"
+                )
+            sum_shares_unknown = sum([s.cast_to(dims_unknown) for s in shares_unknown.values()])
+            self._total = sum_known / (1 - sum_shares_unknown)
+
+    def get_underdetermined_error_message_total(self, sides: List[str]) -> str:
+        message = "Failed to compute total flow of process from given in/outflows.\n"
+        for side in sides:
+            message += f"Tried to compute from {side}flows, but failed. Reasons:\n"
+            if not self.known_flows(side):
+                message += f"- no flow from this side has an absolute value given\n"
+            for linked_process in self.neither_known(side):
+                message += f"- for flow from/to process {linked_process}, neither share nor absolute value is given.\n"
+        return message
+
+    def get_underdetermined_error_message_flows(self, sides: List[str]) -> str:
+        message = ""
+        for side in sides:
+            message += f"Failed to compute {side}flows from total; For more than one {side}flow, neither share nor absolute value was given.\n"
+            message += f"Please provide either share or absolute value for all but one of the flows from/to the processes "
+            message += ", ".join(self.neither_known(side)) + ".\n"
+        return message
+
+    def apply_dimension_splitter(self, sides: list[str] = ["in", "out"]):
+        """Apply the dimension splitter to the total flow."""
+
+        # set union of all unknown flows
+        dims_unknown = DimensionSet(dim_list=[])
+        for side in sides:
+            for flow in self.unknown_flows(side).values():
+                dims_unknown |= flow.dims
+        missing_dims = dims_unknown - self._total.dims
+
+        if not missing_dims:
+            if self.dimension_splitter is not None:
+                self.handle_unused_splitter()
+            return
+
+        if self.dimension_splitter is None:
+            raise ValueError(
+                f"Process {self.name} has missing dimensions {missing_dims.names} for unknown flows, but no dimension splitter is set."
+            )
+
+        splitter_dims = self.dimension_splitter.dims
+        if missing_dims - splitter_dims:
+            raise ValueError(
+                f"Dimension splitter of process {self.name} does not cover all dimensions {missing_dims.names} needed to determine unknown flows from total flow."
+            )
+
+        common_dims = splitter_dims & self._total.dims
+        splitter_sum = self.dimension_splitter.sum_to(common_dims.letters)
+        if np.max(np.abs((splitter_sum.values - 1))) > self.tolerance:
+            raise ValueError(
+                f"Dimension splitter of process {self.name} does not sum to 1 if summed to common dimensions with process total {common_dims.names}."
+            )
+
+        self._total *= self.dimension_splitter
+
+    def handle_unused_splitter(self):
+        message = f"In Process {self.name}: Dimension splitter is set, but not used. Given split may not be fulfilled."
+        handle_error(
+            behavior=config.error_behaviors.unused_dimension_splitter,
+            message=message
+        )
+
+    def compute_flows(self, sides: List[str] = ["in", "out"]):
+        """Compute the flows based on the total flow."""
+
+        if not self.can_compute_flows(sides):
+            message = self.get_underdetermined_error_message_flows(sides)
+            raise UnderdeterminedError(process=self, message=message)
+
+        for side in sides:
+            # saving in temp flow avoids reducing dimensions.
+            # This may be important for inferring the last flow by subtracting all known from the total,
+            # because the dimension set intersection is used for that subtraction.
+            temp_flows = {}
+            for share_name, share in self.shares(side).items():
+                if share_name in self.unknown_flows(side):
+                    if share.dims - self._total.dims:
+                        names = ", ".join((share.dims - self._total.dims).names)
+                        raise ValueError(
+                            f"In Process {self.name}: Share of flow to/from process {share_name} "
+                            f"has dimensions {names} not contained in the processes' total "
+                            f"dimensions {', '.join(self._total.dims.names)}. If you wish to "
+                            "perform this dimensional split, consider outsourcing it to its own "
+                            "process with a dimension_splitter."
+                        )
+                    temp_flows[share_name] = self._total * share
+            # calculate the last by sum, if necessary
+            if len(self.unknown_flows(side)) - len(temp_flows) == 1:
+                unknown_name = [n for n in self.unknown_flows(side) if n not in temp_flows][0]
+                unknown_flow = self.unknown_flows(side)[unknown_name]
+                sum_known = sum(self.known_flows(side).values()) + sum(temp_flows.values())
+                if isinstance(sum_known, FlodymArray) and unknown_flow.dims - sum_known.dims:
+                    known_names = ", ".join(self.known_flows(side))
+                    missing_names = ", ".join((unknown_flow.dims - sum_known.dims).names)
+                    raise ValueError(
+                        f"In Process {self.name}: One of the flows with set values ({known_names}) "
+                        f"is missing dimensions ({missing_names}), which are needed to compute "
+                        f"the unknown flow from/to process {unknown_name} by subtracting known "
+                        "flows from the total."
+                    )
+                unknown_flow[...] = self._total - sum_known
+            # reduce dimensions and transfer to actual flows
+            for flow_name, flow in temp_flows.items():
+                self.flows(side)[flow_name][...] = flow
+
+    def check_shares(self, sides: List[str] = ["in", "out"]):
+        if not config.checks.process_shares:
+            return
+        for side in sides:
+            for name, share in self.shares(side).items():
+                error = self._total * share - self.flows(side)[name]
+                max_error = np.max(np.abs(error.values))
+                if max_error > self.tolerance:
+                    message = (
+                        f"after computation of process {self.name}: Share of flow to/from process "
+                        f"{name} is not fulfilled (error = {max_error})."
+                    )
+                    if self._was_overdetermined:
+                        message += (
+                            "This may be due to the process being overdetermined."
+                            "If it is not intentional, consider removing some shares or given flows."
+                        )
+                    else:
+                        message += "This may be due to lacking float precision, or an internal flodym error."
+                    handle_error(
+                        behavior=config.error_behaviors.process_shares,
+                        message=message
+                    )
+
+    def get_sum_inflows(self) -> FlodymArray:
+        """Sum of all inflows to the process."""
+        if not self.is_computed:
+            raise ValueError(f"Cannot compute sum_inflows for process {self.name} before it is computed.")
+        if not self.inflows:
+            return 0.
+        return sum(self.inflows.values())
+
+    def get_sum_outflows(self) -> FlodymArray:
+        """Sum of all outflows from the process."""
+        if not self.is_computed:
+            raise ValueError(f"Cannot compute sum_outflows for process {self.name} before it is computed.")
+        if not self.outflows:
+            return 0.
+        return sum(self.outflows.values())
+
+    def get_net_inflow(self):
+        return self.get_sum_inflows() - self.get_sum_outflows()
+
+    @property
+    def _absolute_float_precision(self) -> float:
+        """The numpy float precision, multiplied by the maximum absolute flow or stock value."""
+        if self.inflows:
+            max_inflow = max([f._absolute_float_precision for f in self.inflows.values()])
+        else:
+            max_inflow = 0.
+        if self.outflows:
+            max_outflow = max([f._absolute_float_precision for f in self.outflows.values()])
+        else:
+            max_outflow = 0.
+        return max(max_inflow, max_outflow)
+
+    @property
+    def tolerance(self) -> float:
+        """The tolerance for checks like mass balance"""
+        if config.absolute_tolerance is not None:
+            return config.absolute_tolerance
+        return config.relative_tolerance * self._absolute_float_precision
+
+    def check_mass_balance(self, tolerance: float = None, error_behavior: ErrorBehavior = None, mass_change_target: FlodymArray = None):
+        """Compute mass balance, and check whether it is within a certain tolerance.
+        Throw an error if it isn't.
+
+        Args:
+            tolerance (float, optional): A tolerance override for the mass balance check.
+                If None, takes the  processes's own tolerance
+            error_behavior (ErrorBehavior): What to do if the mass balance check fails.
+                If None, takes the global config setting, which defaults to raising an error
+        """
+
+        if self.id == 0 and mass_change_target is None:
+            logging.info(f"mass_change_target not given. Skip mass balance check for system environment.")
+            return
+
+        logging.info(f"Checking mass balance of {self.__class__.__name__} object...")
+
+        if mass_change_target is None:
+            mass_change_target = 0. if self.stock is None else self.stock.net_inflow
+        # net_inflow = mass_change, so the difference should be zero
+        mass_balance = self.get_net_inflow() - mass_change_target
+        max_error =  np.max(np.abs(mass_balance.values))
+        if tolerance is None:
+            tolerance = self.tolerance
+        if max_error > tolerance:
+            message = f"In process {self.name}: Mass balance check failed (error = {max_error})"
+            if error_behavior is None:
+                error_behavior = config.error_behaviors.mass_balance
+            handle_error(behavior=error_behavior, message=message)
+        else:
+            logging.info(f"In process {self.name}: Success - Mass balance is consistent!")
+
+
+def make_processes(definitions: List[str|ProcessDefinition]) -> dict[str, Process]:
     """Create a dictionary of processes from a list of process names."""
-    return {name: Process(name=name, id=id) for id, name in enumerate(definitions)}
+    processes = {}
+    for definition in definitions:
+        if isinstance(definition, str):
+            name = definition
+            id = len(processes)
+        elif isinstance(definition, ProcessDefinition):
+            if definition.id != len(processes):
+                raise ValueError(f"Processes must be defined with consecutive IDs starting from 0, but found {definition.id} in {len(processes)}'th definition.")
+            name = definition.name
+            id = definition.id
+        processes[name] = Process(name=name, id=id)
+    return processes
+
+
+def set_process_parameters(processes: Dict[str, Process], definitions: List[ProcessDefinition], parameters: Dict[str, Parameter]):
+    for definition in definitions:
+        if isinstance(definition, str):
+            continue
+
+        if definition.name not in processes:
+            raise ValueError(f"Process {definition.name} is not defined in the processes dictionary.")
+        process = processes[definition.name]
+
+        if definition.inflow_shares:
+            for from_process, parameter_name in definition.inflow_shares.items():
+                if parameter_name not in parameters:
+                    raise ValueError(f"Parameter {parameter_name} given in definition of process {definition.name} is not defined.")
+                process.add_inflow_share(from_process, parameters[parameter_name])
+
+        if definition.outflow_shares:
+            for to_process, parameter_name in definition.outflow_shares.items():
+                if parameter_name not in parameters:
+                    raise ValueError(f"Parameter {parameter_name} given in definition of process {definition.name} is not defined.")
+                process.add_outflow_share(to_process, parameters[parameter_name])
+
+        if definition.dimension_splitter:
+            if definition.dimension_splitter not in parameters:
+                raise ValueError(f"Dimension splitter {definition.dimension_splitter} given in definition of process {definition.name} is not defined.")
+            process.dimension_splitter = parameters[definition.dimension_splitter]

--- a/flodym/processes.py
+++ b/flodym/processes.py
@@ -1,9 +1,11 @@
-from typing import List
-
+from typing import List, Dict, Optional
 from pydantic import BaseModel as PydanticBaseModel, model_validator
 
+from .flodym_arrays import Flow
+from .stocks import Stock
+from .mfa_definition import ProcessDefinition
 
-class Process(PydanticBaseModel):
+class Process(PydanticBaseModel, arbitrary_types_allowed=True):
     """Processes serve as nodes for the MFA system layout definition.
     Flows are defined between two processes. Stocks are connected to a process.
     Processes do not contain values themselves.
@@ -17,6 +19,11 @@ class Process(PydanticBaseModel):
     """Name of the process."""
     id: int
     """ID of the process."""
+    _inflows: Dict[str, Flow] = {}
+    """Inflows to the process, keyed by linked process name."""
+    _outflows: Dict[str, Flow] = {}
+    """Outflows from the process, keyed by linked process name."""
+    stock: Optional[Stock] = None
 
     @model_validator(mode="after")
     def check_id0(self):
@@ -27,7 +34,53 @@ class Process(PydanticBaseModel):
             )
         return self
 
+    def __repr__(self):
+        return ""  # TODO
 
-def make_processes(definitions: List[str]) -> dict[str, Process]:
+    @property
+    def inflows(self) -> Dict[str, Flow]:
+        """Inflows to the process."""
+        return self._inflows
+
+    @property
+    def outflows(self) -> Dict[str, Flow]:
+        """Outflows from the process."""
+        return self._outflows
+
+    def add_inflow(self, flow: Flow) -> None:
+        """Add an inflow flow to the process."""
+        self._inflows[flow.from_process.name] = flow
+
+    def add_outflow(self, flow: Flow) -> None:
+        """Add an outflow flow from the process."""
+        self._outflows[flow.to_process.name] = flow
+
+    def remove_inflow(self, from_process: str) -> None:
+        """Remove an inflow from the process."""
+        if from_process in self._inflows:
+            del self._inflows[from_process]
+        else:
+            raise ValueError(f"In process {self.name}: No inflow from process '{from_process}' found.")
+
+    def remove_outflow(self, to_process: str) -> None:
+        """Remove an outflow from the process."""
+        if to_process in self._outflows:
+            del self._outflows[to_process]
+        else:
+            raise ValueError(f"In process {self.name}: No outflow to process '{to_process}' found.")
+
+
+def make_processes(definitions: List[str|ProcessDefinition]) -> dict[str, Process]:
     """Create a dictionary of processes from a list of process names."""
-    return {name: Process(name=name, id=id) for id, name in enumerate(definitions)}
+    processes = {}
+    for definition in definitions:
+        if isinstance(definition, str):
+            name = definition
+            id = len(processes)
+        elif isinstance(definition, ProcessDefinition):
+            if definition.id != len(processes):
+                raise ValueError(f"Processes must be defined with consecutive IDs starting from 0, but found {definition.id} in {len(processes)}'th definition.")
+            name = definition.name
+            id = definition.id
+        processes[name] = Process(name=name, id=id)
+    return processes

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -16,13 +16,13 @@ from .lifetime_models import LifetimeModel, UnevenTimeDim
 
 
 def stock_compute_decorator(func):
-    """Adds checks before and after every stock compute routine
-    """
+    """Adds checks before and after every stock compute routine"""
 
-    def wrapper(self: 'Stock', *args, **kwargs):
+    def wrapper(self: "Stock", *args, **kwargs):
         self._check_needed_arrays()
         func(self, *args, **kwargs)
         self.mark_computed()
+
     wrapper.is_decorated = True
 
     return wrapper
@@ -88,7 +88,7 @@ class Stock(PydanticBaseModel):
 
     @model_validator(mode="after")
     def check_compute_decorator(self):
-        if not getattr(self.compute, 'is_decorated', False):
+        if not getattr(self.compute, "is_decorated", False):
             raise RuntimeError(
                 "Stock.compute method must have the stock_compute_decorator applied to it."
             )
@@ -160,11 +160,7 @@ class Stock(PydanticBaseModel):
         """Check whether the stock has been computed, i.e. whether the stock, inflow, and outflow arrays
         are all set.
         """
-        return (
-            self.inflow.is_set
-            and self.outflow.is_set
-            and self.stock.is_set
-        )
+        return self.inflow.is_set and self.outflow.is_set and self.stock.is_set
 
     def _to_whole_period(self, annual_flow: np.ndarray) -> np.ndarray:
         """multiply annual flow by interval length to get flow over whole period."""

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -4,15 +4,31 @@ including flow-driven stocks and dynamic (lifetime-based) stocks.
 
 from abc import abstractmethod
 import numpy as np
-from scipy.linalg import solve_triangular
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 import logging
 
-from .processes import Process
+if TYPE_CHECKING:
+    from .processes import Process
 from .flodym_arrays import StockArray, FlodymArray
 from .dimensions import DimensionSet
 from .lifetime_models import LifetimeModel, UnevenTimeDim
+from .config import config, handle_error, ErrorBehavior
+
+
+def stock_compute_decorator(func):
+    """Adds checks before and after every stock compute routine
+    """
+
+    def wrapper(self: 'Stock', *args, **kwargs):
+        self._check_needed_arrays()
+        func(self, *args, **kwargs)
+        self.mark_computed()
+        if config.checks.mass_balance_stocks:
+            self.check_mass_balance()
+    wrapper.is_decorated = True
+
+    return wrapper
 
 
 class Stock(PydanticBaseModel):
@@ -37,7 +53,7 @@ class Stock(PydanticBaseModel):
     """Outflow from the stock"""
     name: Optional[str] = "unnamed"
     """Name of the stock"""
-    process: Optional[Process] = None
+    process: Optional['Process'] = None
     """Process the stock is associated with, if any. Needed for example for the mass balance."""
     time_letter: str = "t"
     """Letter of the time dimension in the dimensions set, to make sure it's the first one."""
@@ -74,18 +90,45 @@ class Stock(PydanticBaseModel):
         return self
 
     @model_validator(mode="after")
+    def add_to_process(self):
+        if self.process is not None:
+            self.process.stock = self
+        return self
+
+    @model_validator(mode="after")
+    def check_compute_decorator(self):
+        if not getattr(self.compute, 'is_decorated', False):
+            raise RuntimeError(
+                "Stock.compute method must have the stock_compute_decorator applied to it."
+            )
+        return self
+
+    @model_validator(mode="after")
     def init_t(self):
         self._t = UnevenTimeDim(dim=self.dims[self.time_letter])
         return self
 
     @abstractmethod
+    @stock_compute_decorator
     def compute(self):
-        # always add this check first
-        self._check_needed_arrays()
+        # Add stock_compute_decorator to all subclasses!
+        pass
 
     @abstractmethod
     def _check_needed_arrays(self):
         pass
+
+    @abstractmethod
+    def compute_process(self):
+        """Compute the stock based on the process inflows and outflows.
+        This is called by the process when it computes its total inflow/outflow.
+        """
+        pass
+
+    def mark_computed(self):
+        self.inflow.mark_set()
+        self.outflow.mark_set()
+        self.stock.mark_set()
 
     @property
     def shape(self) -> tuple:
@@ -97,6 +140,15 @@ class Stock(PydanticBaseModel):
         """ID of the process the stock is associated with."""
         return self.process.id
 
+    @property
+    def net_inflow(self) -> FlodymArray:
+        return self.inflow - self.outflow
+
+    @property
+    def time_interval_length(self) -> FlodymArray:
+        t = UnevenTimeDim(dim=self.dims[self.time_letter])
+        return FlodymArray(dims=self.dims[self.time_letter,], values=t.interval_lengths)
+
     def to_stock_type(self, desired_stock_type: type, **kwargs):
         """Return an object of a new stock type with values and dimensions the same as the original.
         `**kwargs` can be used to pass additional model attributes as required by the desired stock
@@ -104,22 +156,64 @@ class Stock(PydanticBaseModel):
         """
         return desired_stock_type(**self.__dict__, **kwargs)
 
-    def check_stock_balance(self):
-        balance = self.get_stock_balance()
-        balance = np.max(np.abs(balance).sum(axis=0))
-        if balance > 1:  # 1 tonne accuracy
-            raise RuntimeError("Stock balance for dynamic stock model is too high: " + str(balance))
-        elif balance > 0.001:
-            print("Stock balance for model dynamic stock model is noteworthy: " + str(balance))
+    def tolerance(self) -> float:
+        if config.absolute_tolerance is not None:
+            return config.absolute_tolerance
+        return config.relative_tolerance * max(
+                self.inflow._absolute_float_precision,
+                self.outflow._absolute_float_precision,
+                self.stock._absolute_float_precision,
+            )
 
-    def get_stock_balance(self) -> np.ndarray:
+    def check_mass_balance(self, tolerance: float = None, error_behavior: ErrorBehavior = None):
+        """Compute mass balance, and check whether it is within a certain tolerance.
+        Throw an error if it isn't.
+
+        Args:
+            tolerance (float, optional): The tolerance for the mass balance check.
+                If None, takes the global config setting, which defaults to 100 times the numpy
+                float precision, multiplied by the maximum absolute flow value.
+            error_behavior (ErrorBehavior): What to do if the mass balance check fails.
+                If None, takes the global config setting, which defaults to raising an error
+        """
+        max_error = np.max(np.abs(self.balance.values))
+        if tolerance is None:
+            tolerance = config.absolute_tolerance
+        if error_behavior is None:
+            error_behavior = config.error_behaviors.mass_balance
+        if tolerance is None:
+            tolerance = self.tolerance()
+        if max_error > tolerance:
+            message = f"In stock {self.name}: Mass balance check failed (error = {max_error})"
+            handle_error(
+                behavior=error_behavior,
+                message=message,
+            )
+        else:
+            logging.info(f"In stock {self.name}: Success - Mass balance is consistent!")
+
+    @property
+    def balance(self) -> FlodymArray:
         """Check whether inflow, outflow, and stock are balanced.
         If possible, the method returns the vector 'Balance', where Balance = inflow - outflow - stock_change
         """
-        dsdt = np.diff(
-            self.stock.values, axis=0, prepend=0
-        )  # stock_change(t) = stock(t) - stock(t-1)
-        return self.inflow.values - self.outflow.values - dsdt
+        net_addition_to_stock = self.net_inflow * self.time_interval_length
+        return net_addition_to_stock - self.stock_change
+
+    @property
+    def stock_change(self) -> FlodymArray:
+        return self.stock.apply(np.diff, kwargs={"axis": 0, "prepend": 0})
+
+    @property
+    def is_computed(self) -> bool:
+        """Check whether the stock has been computed, i.e. whether the stock, inflow, and outflow arrays
+        are all set.
+        """
+        return (
+            self.inflow.is_set
+            and self.outflow.is_set
+            and self.stock.is_set
+        )
 
     def _to_whole_period(self, annual_flow: np.ndarray) -> np.ndarray:
         """multiply annual flow by interval length to get flow over whole period."""
@@ -140,16 +234,44 @@ class SimpleFlowDrivenStock(Stock):
 
     def _check_needed_arrays(self):
         if (
-            np.max(np.abs(self.inflow.values)) < 1e-10
-            and np.max(np.abs(self.outflow.values)) < 1e-10
+            not self.inflow.is_set
+            and not self.outflow.is_set
         ):
-            logging.warning("Inflow and Outflow are zero. This will lead to a zero stock.")
+            logging.warning("Neither inflow and outflow are set (is_set=False). If this is intended, perform mark_set() on one of them.")
 
+    @stock_compute_decorator
     def compute(self):
         self._check_needed_arrays()
         annual_net_inflow = self.inflow.values - self.outflow.values
         net_inflow_whole_period = self._to_whole_period(annual_net_inflow)
         self.stock.values[...] = np.cumsum(net_inflow_whole_period, axis=0)
+
+    def compute_process(self):
+        if self.process.inflows:
+            self.process.compute_total(try_sides=["in"])
+            if self.inflow.dims - self.process._total.dims:
+                names = ", ".join((self.inflow.dims - self.process._total.dims).names)
+                raise ValueError(
+                    f"In Process {self.process.name}: Stock inflow has dimensions {names} not contained in the "
+                    "dimensions of the summed inflow Flows. Consider using less dimensions for the "
+                    "stock or a preceding process with a dimension_splitter."
+                )
+            self.inflow[...] = self.process._total
+
+        if self.process.outflows:
+            self.process.compute_total(try_sides=["out"])
+            if self.outflow.dims - self.process._total.dims:
+                names = ", ".join((self.outflow.dims - self.process._total.dims).names)
+                raise ValueError(
+                    f"In Process {self.process.name}: Stock outflow has dimensions {names} not contained in the "
+                    "dimensions of the summed outflow Flows. Consider using less dimensions for the "
+                    "stock or a neighboring process with a dimension_splitter."
+                )
+            self.outflow[...] = self.process._total
+
+        self.process.check_shares()
+        self.compute()
+
 
 
 class DynamicStockModel(Stock):
@@ -227,12 +349,12 @@ class InflowDrivenDSM(DynamicStockModel):
 
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
-        if np.allclose(self.inflow.values, np.zeros(self.shape)):
-            logging.warning("Inflow is zero. This will lead to a zero stock and outflow.")
+        if not self.inflow.is_set:
+            logging.warning("Inflow is not set (is_set=False). If this is intended, perform mark_set() on it.")
 
+    @stock_compute_decorator
     def compute(self):
         """Determine stocks and outflows and store values in the class instance."""
-        self._check_needed_arrays()
         self._compute_stock()
         self._compute_outflow()
 
@@ -244,6 +366,22 @@ class InflowDrivenDSM(DynamicStockModel):
         )
         self.stock.values[...] = self._stock_by_cohort.sum(axis=1)
 
+    def compute_process(self):
+        if self.inflow.is_set:
+            self.compute()
+            self.process._total = self.inflow
+            self.process.compute_flows(sides=["in"])
+            self.process.check_shares(sides=["in"])
+        else:
+            self.process.compute_total(try_sides=["in"])
+            self.inflow[...] = self.process._total
+            self.compute()
+
+        self.process._total = self.outflow
+        self.process.apply_dimension_splitter(sides=["out"])
+        self.process.compute_flows(sides=["out"])
+        self.process.check_shares(sides=["out"])
+
 
 class StockDrivenDSM(DynamicStockModel):
     """Stock driven model.
@@ -252,27 +390,14 @@ class StockDrivenDSM(DynamicStockModel):
     where A is the survival function matrix, x is the inflow vector, and b is the stock vector.
     """
 
-    solver: str = "manual"
-    """Algorithm to use for solving the equation system.  Options are: "manual" (default), which uses
-    an own python implementation, and "lapack", which calls the lapack trtrs routine via scipy.
-    The lapack implementation may be more precise. Speed depends on the dimensionality,
-    but the manual implementation is usually faster.
-    """
-
-    @model_validator(mode="after")
-    def init_solver(self):
-        if self.solver not in ["manual", "lapack"]:
-            raise ValueError("Solver must be either 'manual' or 'lapack'.")
-        return self
-
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
-        if np.allclose(self.stock.values, np.zeros(self.shape)):
-            logging.warning("Stock is zero. This will lead to a zero inflow and outflow.")
+        if not self.stock.is_set:
+            logging.warning("Stock is not set (is_set=False). If this is intended, perform mark_set() on it.")
 
+    @stock_compute_decorator
     def compute(self):
         """Determine inflows and outflows and store values in the class instance."""
-        self._check_needed_arrays()
         self._compute_cohorts_and_inflow()
         self._compute_outflow()
 
@@ -281,22 +406,6 @@ class StockDrivenDSM(DynamicStockModel):
         the method builds the stock by cohort and the inflow.
         This involves solving the lower triangular equation system A*x=b,
         where A is the survival function matrix, x is the inflow vector, and b is the stock vector.
-        """
-        if self.solver == "manual":
-            self._compute_inflow_manual()
-        elif self.solver == "lapack":
-            self._compute_inflow_lapack()
-        else:
-            raise ValueError(f"Unknown engine: {self.solver}")
-
-        self._stock_by_cohort = np.einsum(
-            "c...,tc...->tc...", self.inflow.values, self.lifetime_model.sf
-        )
-
-    def _compute_inflow_manual(self) -> tuple[np.ndarray]:
-        """With given total stock and lifetime distribution,
-        the method builds the stock by cohort and the inflow,
-        using a manual algorithm for solving of the equation system (see "solver" doc for details).
         """
         # Maths behind implementation:
         # Solve square linear equation system
@@ -315,17 +424,52 @@ class StockDrivenDSM(DynamicStockModel):
 
             inflow_whole_period[i, ...] = (stock_i - (sf_ij * inflow_j).sum(axis=0)) / sf_ii
         self.inflow.values[...] = self._to_annual(inflow_whole_period)
+        self._stock_by_cohort = np.einsum(
+            "c...,tc...->tc...", self.inflow.values, self.lifetime_model.sf
+        )
 
-    def _compute_inflow_lapack(self) -> tuple[np.ndarray]:
-        """With given total stock and lifetime distribution,
-        the method builds the stock by cohort and the inflow,
-        using lapack for solving of the equation system (see "engine" doc for details).
-        """
-        sf = self.lifetime_model.sf
-        slt = (slice(None),)
-        inflow_whole_period = np.zeros_like(self.inflow.values)
-        for i in np.ndindex(self._shape_no_t):
-            inflow_whole_period[slt + i] = solve_triangular(
-                sf[2 * slt + i], self.stock.values[slt + i], lower=True
-            )
-        self.inflow.values[...] = self._to_annual(inflow_whole_period)
+    def compute_process(self):
+
+        self.compute()
+
+        self.process._total = self.outflow
+        self.process.apply_dimension_splitter(sides=["out"])
+        self.process.compute_flows(sides=["out"])
+        self.process.check_shares(sides=["out"])
+
+        self.process._total = self.inflow
+        self.process.apply_dimension_splitter(sides=["in"])
+        self.process.compute_flows(sides=["in"])
+        self.process.check_shares(sides=["in"])
+
+
+class FlexibleDSM(DynamicStockModel):
+    """Computes either stock-driven or inflow-driven dynamic stock model, depending on which of the
+    stock or inflow is set.
+    """
+
+    compute_stock_driven = StockDrivenDSM.compute
+    compute_inflow_driven = InflowDrivenDSM.compute
+
+    _compute_cohorts_and_inflow = StockDrivenDSM._compute_cohorts_and_inflow
+    _compute_stock = InflowDrivenDSM._compute_stock
+
+    compute_process_stock_driven = StockDrivenDSM.compute_process
+    compute_process_inflow_driven = InflowDrivenDSM.compute_process
+
+    def compute(self):
+        if self.stock.is_set:
+            self.compute_stock_driven()
+        elif self.inflow.is_set:
+            self.compute_inflow_driven()
+        else:
+            raise ValueError("Either stock or inflow must be set for FlexibleDSM.compute().")
+
+    # replaces decorator, since inner functions are already decorated
+    compute.is_decorated = True
+
+    def compute_process(self):
+        if self.stock.is_set:
+            self.compute_process_stock_driven()
+        else:
+            self.compute_process_inflow_driven()

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -131,11 +131,7 @@ class Stock(PydanticBaseModel):
         """Check whether the stock has been computed, i.e. whether the stock, inflow, and outflow arrays
         are all set.
         """
-        return (
-            self.inflow.is_set
-            and self.outflow.is_set
-            and self.stock.is_set
-        )
+        return self.inflow.is_set and self.outflow.is_set and self.stock.is_set
 
     def _to_whole_period(self, annual_flow: np.ndarray) -> np.ndarray:
         """multiply annual flow by interval length to get flow over whole period."""
@@ -155,11 +151,10 @@ class SimpleFlowDrivenStock(Stock):
     """Given inflows and outflows, the stock can be calculated without a lifetime model or cohorts."""
 
     def _check_needed_arrays(self):
-        if (
-            not self.inflow.is_set
-            and not self.outflow.is_set
-        ):
-            logging.warning("Neither inflow and outflow are set (is_set=False). If this is intended, perform mark_set() on one of them.")
+        if not self.inflow.is_set and not self.outflow.is_set:
+            logging.warning(
+                "Neither inflow and outflow are set (is_set=False). If this is intended, perform mark_set() on one of them."
+            )
 
     def compute(self):
         self._check_needed_arrays()
@@ -244,7 +239,9 @@ class InflowDrivenDSM(DynamicStockModel):
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
         if not self.inflow.is_set:
-            logging.warning("Inflow is not set (is_set=False). If this is intended, perform mark_set() on it.")
+            logging.warning(
+                "Inflow is not set (is_set=False). If this is intended, perform mark_set() on it."
+            )
 
     def compute(self):
         """Determine stocks and outflows and store values in the class instance."""
@@ -284,7 +281,9 @@ class StockDrivenDSM(DynamicStockModel):
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
         if not self.stock.is_set:
-            logging.warning("Stock is not set (is_set=False). If this is intended, perform mark_set() on it.")
+            logging.warning(
+                "Stock is not set (is_set=False). If this is intended, perform mark_set() on it."
+            )
 
     def compute(self):
         """Determine inflows and outflows and store values in the class instance."""

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -50,7 +50,7 @@ class Stock(PydanticBaseModel):
     """Outflow from the stock"""
     name: Optional[str] = "unnamed"
     """Name of the stock"""
-    process: Optional['Process'] = None
+    process: Optional["Process"] = None
     """Process the stock is associated with, if any. Needed for example for the mass balance."""
     time_letter: str = "t"
     """Letter of the time dimension in the dimensions set, to make sure it's the first one."""

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -87,6 +87,11 @@ class Stock(PydanticBaseModel):
     def _check_needed_arrays(self):
         pass
 
+    def mark_computed(self):
+        self.inflow.mark_set()
+        self.outflow.mark_set()
+        self.stock.mark_set()
+
     @property
     def shape(self) -> tuple:
         """Shape of the stock, inflow, outflow arrays, defined by the dimensions."""
@@ -121,6 +126,17 @@ class Stock(PydanticBaseModel):
         )  # stock_change(t) = stock(t) - stock(t-1)
         return self.inflow.values - self.outflow.values - dsdt
 
+    @property
+    def is_computed(self) -> bool:
+        """Check whether the stock has been computed, i.e. whether the stock, inflow, and outflow arrays
+        are all set.
+        """
+        return (
+            self.inflow.is_set
+            and self.outflow.is_set
+            and self.stock.is_set
+        )
+
     def _to_whole_period(self, annual_flow: np.ndarray) -> np.ndarray:
         """multiply annual flow by interval length to get flow over whole period."""
         return np.einsum("t...,t->t...", annual_flow, self._t.interval_lengths)
@@ -140,10 +156,10 @@ class SimpleFlowDrivenStock(Stock):
 
     def _check_needed_arrays(self):
         if (
-            np.max(np.abs(self.inflow.values)) < 1e-10
-            and np.max(np.abs(self.outflow.values)) < 1e-10
+            not self.inflow.is_set
+            and not self.outflow.is_set
         ):
-            logging.warning("Inflow and Outflow are zero. This will lead to a zero stock.")
+            logging.warning("Neither inflow and outflow are set (is_set=False). If this is intended, perform mark_set() on one of them.")
 
     def compute(self):
         self._check_needed_arrays()
@@ -227,8 +243,8 @@ class InflowDrivenDSM(DynamicStockModel):
 
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
-        if np.allclose(self.inflow.values, np.zeros(self.shape)):
-            logging.warning("Inflow is zero. This will lead to a zero stock and outflow.")
+        if not self.inflow.is_set:
+            logging.warning("Inflow is not set (is_set=False). If this is intended, perform mark_set() on it.")
 
     def compute(self):
         """Determine stocks and outflows and store values in the class instance."""
@@ -267,8 +283,8 @@ class StockDrivenDSM(DynamicStockModel):
 
     def _check_needed_arrays(self):
         super()._check_needed_arrays()
-        if np.allclose(self.stock.values, np.zeros(self.shape)):
-            logging.warning("Stock is zero. This will lead to a zero inflow and outflow.")
+        if not self.stock.is_set:
+            logging.warning("Stock is not set (is_set=False). If this is intended, perform mark_set() on it.")
 
     def compute(self):
         """Determine inflows and outflows and store values in the class instance."""

--- a/howtos/06_stocks.py
+++ b/howtos/06_stocks.py
@@ -45,7 +45,7 @@ print(f"Array names: {my_stock.stock.name}, {my_stock.inflow.name}, {my_stock.ou
 #
 # As mentioned above, for `SimpleFlowDrivenStock`, the stock is calculated as the cumulative sum over time of inflow minus outflow.
 #
-# There's a `check_stock_balance()` method, which checks whether inflow, outflow and stock are consistent:
+# There's a `check_mass_balance()` method, which checks whether inflow, outflow and stock are consistent:
 
 # %%
 my_stock.inflow.values[...] = 0.1
@@ -54,7 +54,7 @@ my_stock.compute()
 
 print("Stock values for Vehicles:", my_stock.stock["Vehicles"].values)
 
-my_stock.check_stock_balance()
+my_stock.check_mass_balance()
 
 # %% [markdown]
 # ## Dynamic Stock Models (DSM)


### PR DESCRIPTION
## Purpose of this PR

- Introduce a ProcessDefinition class, which allows setting the process ID explicitly. (Does not have to be used, strings are still okay)
- Introduce functions which add a link to inflows, outflows and a stock to the Process class

This created circular dependencies for pydantic's TYPE_CHECKING, which were treated with changes to __init__.

Requires #123 to #125, so they should be merged first

TODO (beyond the usual): 
- implement a better process repr
- allow non-contiguous process IDs
- make sure the actual linking step during setup has survived the merge
- pull flexible_stock after their change to __init__

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix
- [ ] Refactoring
- [x] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [ ] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
