### PR TITLE
reset cached sf/pdf when calling set_prms in LifetimeModel

### DIFF
--- a/flodym/lifetime_models.py
+++ b/flodym/lifetime_models.py
@@ -198,7 +198,7 @@ class LifetimeModel(PydanticBaseModel):
     def set_prms(self, *args, **kwargs):
         """Set parameters and reset cached arrays. Child classes should call `self.reset_cached_arrays()`."""
         self.reset_cached_arrays()
-    
+
     def reset_cached_arrays(self):
         self._sf = None
         self._pdf = None

--- a/flodym/lifetime_models.py
+++ b/flodym/lifetime_models.py
@@ -194,9 +194,10 @@ class LifetimeModel(PydanticBaseModel):
     def _survival_by_year_id(m, **kwargs):
         pass
 
-    @abstractmethod
-    def set_prms(self):
-        pass
+    def set_prms(self, *args, **kwargs):
+        """Set parameters and reset cached arrays. Child classes should call super().set_prms()."""
+        self._sf = None
+        self._pdf = None
 
     def cast_any_to_np_array(self, prm_in):
         if isinstance(prm_in, FlodymArray):
@@ -227,6 +228,7 @@ class FixedLifetime(LifetimeModel):
         return {"mean": self.mean}
 
     def set_prms(self, mean: FlodymArray):
+        super().set_prms()
         self.mean = self.cast_any_to_np_array(mean)
 
     def _survival_by_year_id(self, t, m):
@@ -244,6 +246,7 @@ class StandardDeviationLifetimeModel(LifetimeModel):
         return {"mean": self.mean, "std": self.std}
 
     def set_prms(self, mean: FlodymArray, std: FlodymArray):
+        super().set_prms()
         self.mean = self.cast_any_to_np_array(mean)
         self.std = self.cast_any_to_np_array(std)
 
@@ -317,6 +320,7 @@ class WeibullLifetime(LifetimeModel):
         return {"weibull_shape": self.weibull_shape, "weibull_scale": self.weibull_scale}
 
     def set_prms(self, weibull_shape: FlodymArray, weibull_scale: FlodymArray):
+        super().set_prms()
         self.weibull_shape = self.cast_any_to_np_array(weibull_shape)
         self.weibull_scale = self.cast_any_to_np_array(weibull_scale)
 

--- a/flodym/lifetime_models.py
+++ b/flodym/lifetime_models.py
@@ -194,8 +194,12 @@ class LifetimeModel(PydanticBaseModel):
     def _survival_by_year_id(m, **kwargs):
         pass
 
+    @abstractmethod
     def set_prms(self, *args, **kwargs):
-        """Set parameters and reset cached arrays. Child classes should call super().set_prms()."""
+        """Set parameters and reset cached arrays. Child classes should call `self.reset_cached_arrays()`."""
+        self.reset_cached_arrays()
+    
+    def reset_cached_arrays(self):
         self._sf = None
         self._pdf = None
 
@@ -228,7 +232,7 @@ class FixedLifetime(LifetimeModel):
         return {"mean": self.mean}
 
     def set_prms(self, mean: FlodymArray):
-        super().set_prms()
+        self.reset_cached_arrays()
         self.mean = self.cast_any_to_np_array(mean)
 
     def _survival_by_year_id(self, t, m):
@@ -246,7 +250,7 @@ class StandardDeviationLifetimeModel(LifetimeModel):
         return {"mean": self.mean, "std": self.std}
 
     def set_prms(self, mean: FlodymArray, std: FlodymArray):
-        super().set_prms()
+        self.reset_cached_arrays()
         self.mean = self.cast_any_to_np_array(mean)
         self.std = self.cast_any_to_np_array(std)
 
@@ -320,7 +324,7 @@ class WeibullLifetime(LifetimeModel):
         return {"weibull_shape": self.weibull_shape, "weibull_scale": self.weibull_scale}
 
     def set_prms(self, weibull_shape: FlodymArray, weibull_scale: FlodymArray):
-        super().set_prms()
+        self.reset_cached_arrays()
         self.weibull_shape = self.cast_any_to_np_array(weibull_shape)
         self.weibull_scale = self.cast_any_to_np_array(weibull_scale)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flodym"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     {name = "Jakob Dürrwächter"},
     {name = "Sally Dacie"},


### PR DESCRIPTION
## Purpose of this PR
When setting lifetime parameters via `LifetimeModel.set_prms()`, the internal variables `_sf` and `_pdf` are not reset, leading to issues. In this change, both of them are reset to `None` such that when their respective property is called, they are recalculated.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix
- [ ] Refactoring
- [ ] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [x] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
