### PR TITLE
feat: add a copy option to fd stocks

### DIFF
--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -104,6 +104,22 @@ class Stock(PydanticBaseModel):
         """
         return desired_stock_type(**self.__dict__, **kwargs)
 
+    def copy(self) -> "Stock":
+        """Return a copy of the Stock.
+
+        The copy has its own :py:class:`flodym.DimensionSet` and its own stock, inflow and
+        outflow arrays (created via :py:meth:`flodym.FlodymArray.copy`), so that modifications
+        to either the copy or the original do not affect the other.
+        """
+        return self.model_copy(
+            update={
+                "dims": self.dims.copy(),
+                "stock": self.stock.copy(),
+                "inflow": self.inflow.copy(),
+                "outflow": self.outflow.copy(),
+            }
+        )
+
     def check_stock_balance(self):
         balance = self.get_stock_balance()
         balance = np.max(np.abs(balance).sum(axis=0))
@@ -213,6 +229,15 @@ class DynamicStockModel(Stock):
             "c...,tc...->tc...", self.inflow.values, self.lifetime_model.pdf
         )
         self.outflow.values[...] = self._outflow_by_cohort.sum(axis=1)
+
+    def copy(self) -> "Stock":
+        """Return a copy of the Stock, as :py:meth:`flodym.Stock.copy`, but additionally
+        giving the copy its own independent ``lifetime_model`` so that, for example, calling
+        ``set_prms`` on the copy does not affect the original.
+        """
+        new_stock = super().copy()
+        new_stock.lifetime_model = self.lifetime_model.model_copy(deep=True)
+        return new_stock
 
     def __str__(self):
         base = super().__str__()

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -6,13 +6,15 @@ from abc import abstractmethod
 import numpy as np
 from scipy.linalg import solve_triangular
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator
-from typing import Optional, Union
+from typing import Optional, Union, TypeVar, Type
 import logging
 
 from .processes import Process
 from .flodym_arrays import StockArray, FlodymArray
 from .dimensions import DimensionSet
 from .lifetime_models import LifetimeModel, UnevenTimeDim
+
+StockSubtype = TypeVar("StockSubtype", bound="Stock")
 
 
 class Stock(PydanticBaseModel):
@@ -97,7 +99,7 @@ class Stock(PydanticBaseModel):
         """ID of the process the stock is associated with."""
         return self.process.id
 
-    def to_stock_type(self, desired_stock_type: type, **kwargs):
+    def to_stock_type(self, desired_stock_type: Type[StockSubtype], **kwargs) -> StockSubtype:
         """Return an object of a new stock type with values and dimensions the same as the original.
         `**kwargs` can be used to pass additional model attributes as required by the desired stock
         type, if these are not contained in the original stock type.

--- a/tests/test_stocks.py
+++ b/tests/test_stocks.py
@@ -6,7 +6,7 @@ from flodym.dimensions import Dimension, DimensionSet
 from flodym.flodym_arrays import StockArray
 from flodym.mfa_definition import StockDefinition
 from flodym.stock_helper import make_empty_stocks
-from flodym.stocks import InflowDrivenDSM, StockDrivenDSM
+from flodym.stocks import InflowDrivenDSM, StockDrivenDSM, SimpleFlowDrivenStock
 from flodym.lifetime_models import LogNormalLifetime
 
 dim_list = [
@@ -64,6 +64,61 @@ def test_stocks():
     inflow_post_invert = stock_driven_dsm.inflow
     assert np.allclose(inflow.values, inflow_post_invert.values)
     # return inflow, inflow_post, inflow_post_invert
+
+
+def test_simple_stock_copy():
+    """Copying a base (flow-driven) stock yields independent dims and arrays."""
+    inflow = StockArray(dims=dims, values=np.ones((dims["t"].len, 2)))
+    outflow = StockArray(dims=dims, values=np.zeros((dims["t"].len, 2)))
+    stock = SimpleFlowDrivenStock(dims=dims, inflow=inflow, outflow=outflow, time_letter="t")
+    stock.compute()
+
+    stock_copy = stock.copy()
+
+    # same type, equal values, but distinct objects
+    assert isinstance(stock_copy, SimpleFlowDrivenStock)
+    assert stock_copy is not stock
+    assert stock_copy.dims is not stock.dims
+    assert stock_copy.stock is not stock.stock
+    assert stock_copy.stock.values is not stock.stock.values
+    assert np.allclose(stock_copy.stock.values, stock.stock.values)
+
+    # in-place mutation of the copy does not propagate back to the original
+    stock_copy.stock.values[...] = 999.0
+    assert not np.allclose(stock.stock.values, stock_copy.stock.values)
+
+
+def test_dynamic_stock_copy():
+    """Copying a dynamic stock yields independent arrays and an independent lifetime model."""
+    inflow_values = np.exp(-np.linspace(-2, 2, 201) ** 2)
+    inflow_values = np.stack([inflow_values, inflow_values]).T
+    inflow = StockArray(dims=dims, values=inflow_values)
+    lifetime_model = LogNormalLifetime(dims=dims, time_letter="t", mean=60, std=25)
+    dsm = InflowDrivenDSM(dims=dims, inflow=inflow, lifetime_model=lifetime_model, time_letter="t")
+    dsm.compute()
+
+    dsm_copy = dsm.copy()
+
+    # subclass preserved, values equal, objects distinct (incl. lifetime model)
+    assert isinstance(dsm_copy, InflowDrivenDSM)
+    assert dsm_copy is not dsm
+    assert dsm_copy.inflow is not dsm.inflow
+    assert dsm_copy.stock.values is not dsm.stock.values
+    assert dsm_copy.lifetime_model is not dsm.lifetime_model
+    assert np.allclose(dsm_copy.stock.values, dsm.stock.values)
+
+    # in-place array mutation stays local to the copy
+    original_inflow = dsm.inflow.values.copy()
+    dsm_copy.inflow.values[...] = 0.0
+    assert np.allclose(dsm.inflow.values, original_inflow)
+
+    # changing the copy's lifetime model and recomputing leaves the original untouched
+    stock_before = dsm.stock.values.copy()
+    dsm_copy.inflow.values[...] = inflow_values  # restore so recompute is meaningful
+    dsm_copy.lifetime_model.set_prms(mean=10, std=5)
+    dsm_copy.compute()
+    assert np.allclose(dsm.stock.values, stock_before)
+    assert not np.allclose(dsm_copy.stock.values, stock_before)
 
 
 def test_lifetime_quadrature():

--- a/tests/test_stocks.py
+++ b/tests/test_stocks.py
@@ -85,6 +85,10 @@ def test_simple_stock_copy():
 
     # dims and all three arrays are distinct objects with equal values
     assert stock_copy.dims is not stock.dims
+    assert stock_copy.dims.letters == stock.dims.letters
+    assert stock_copy.dims.names == stock.dims.names
+    for letter in stock.dims.letters:
+        assert stock_copy.dims[letter].items == stock.dims[letter].items
     for attr in ("stock", "inflow", "outflow"):
         original_array = getattr(stock, attr)
         copied_array = getattr(stock_copy, attr)
@@ -111,26 +115,45 @@ def test_dynamic_stock_copy():
 
     dsm_copy = dsm.copy()
 
-    # subclass preserved, values equal, objects distinct (incl. lifetime model)
+    # same type, but distinct objects
     assert isinstance(dsm_copy, InflowDrivenDSM)
     assert dsm_copy is not dsm
-    assert dsm_copy.inflow is not dsm.inflow
-    assert dsm_copy.stock.values is not dsm.stock.values
-    assert dsm_copy.lifetime_model is not dsm.lifetime_model
-    assert np.allclose(dsm_copy.stock.values, dsm.stock.values)
 
-    # in-place array mutation stays local to the copy
-    original_inflow = dsm.inflow.values.copy()
-    dsm_copy.inflow.values[...] = 0.0
-    assert np.allclose(dsm.inflow.values, original_inflow)
+    # scalar attributes are preserved on the copy
+    assert dsm_copy.name == dsm.name
+    assert dsm_copy.time_letter == dsm.time_letter
+
+    # dims and all three arrays are distinct objects with equal values
+    assert dsm_copy.dims is not dsm.dims
+    assert dsm_copy.dims.letters == dsm.dims.letters
+    assert dsm_copy.dims.names == dsm.dims.names
+    for letter in dsm.dims.letters:
+        assert dsm_copy.dims[letter].items == dsm.dims[letter].items
+    for attr in ("stock", "inflow", "outflow"):
+        original_array = getattr(dsm, attr)
+        copied_array = getattr(dsm_copy, attr)
+        assert copied_array is not original_array
+        assert copied_array.values is not original_array.values
+        assert np.allclose(copied_array.values, original_array.values)
+
+    # the lifetime model is a distinct object whose parameters start out equal
+    assert dsm_copy.lifetime_model is not dsm.lifetime_model
+    for prm_name, prm in dsm.lifetime_model.prms.items():
+        assert np.allclose(dsm_copy.lifetime_model.prms[prm_name], prm)
 
     # changing the copy's lifetime model and recomputing leaves the original untouched
     stock_before = dsm.stock.values.copy()
-    dsm_copy.inflow.values[...] = inflow_values  # restore so recompute is meaningful
     dsm_copy.lifetime_model.set_prms(mean=10, std=5)
     dsm_copy.compute()
     assert np.allclose(dsm.stock.values, stock_before)
     assert not np.allclose(dsm_copy.stock.values, stock_before)
+
+    # in-place mutation of the copy does not propagate back to the original
+    for attr in ("stock", "inflow", "outflow"):
+        getattr(dsm_copy, attr).values[...] = 999.0
+        assert not np.any(getattr(dsm, attr).values == 999.0)
+        getattr(dsm, attr).values[...] = -1.0
+        assert not np.any(getattr(dsm_copy, attr).values == -1.0)
 
 
 def test_lifetime_quadrature():

--- a/tests/test_stocks.py
+++ b/tests/test_stocks.py
@@ -75,17 +75,29 @@ def test_simple_stock_copy():
 
     stock_copy = stock.copy()
 
-    # same type, equal values, but distinct objects
+    # same type, but distinct objects
     assert isinstance(stock_copy, SimpleFlowDrivenStock)
     assert stock_copy is not stock
+
+    # scalar attributes are preserved on the copy
+    assert stock_copy.name == stock.name
+    assert stock_copy.time_letter == stock.time_letter
+
+    # dims and all three arrays are distinct objects with equal values
     assert stock_copy.dims is not stock.dims
-    assert stock_copy.stock is not stock.stock
-    assert stock_copy.stock.values is not stock.stock.values
-    assert np.allclose(stock_copy.stock.values, stock.stock.values)
+    for attr in ("stock", "inflow", "outflow"):
+        original_array = getattr(stock, attr)
+        copied_array = getattr(stock_copy, attr)
+        assert copied_array is not original_array
+        assert copied_array.values is not original_array.values
+        assert np.allclose(copied_array.values, original_array.values)
 
     # in-place mutation of the copy does not propagate back to the original
-    stock_copy.stock.values[...] = 999.0
-    assert not np.allclose(stock.stock.values, stock_copy.stock.values)
+    for attr in ("stock", "inflow", "outflow"):
+        getattr(stock_copy, attr).values[...] = 999.0
+        assert not np.any(getattr(stock, attr).values == 999.0)
+        getattr(stock, attr).values[...] = -1.0
+        assert not np.any(getattr(stock_copy, attr).values == -1.0)
 
 
 def test_dynamic_stock_copy():


### PR DESCRIPTION
## Purpose of this PR

Stocks could not easily copied before, so this PR offers a built-in solution for that. It draws on the concepts and implementation style of the already-existing copy option for FlodymArrays.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix
- [ ] Refactoring
- [x] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [ ] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
