### PR TITLE
fix: enhance `Dimension.from_np` to support pandas string arrays

### DIFF
--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+
 from copy import copy
-from pydantic import BaseModel as PydanticBaseModel, Field, AliasChoices, model_validator
 from typing import Dict, Iterator, Optional
+
 import numpy as np
 import pandas as pd
+from pydantic import AliasChoices, Field, model_validator
+from pydantic import BaseModel as PydanticBaseModel
 
 from .mfa_definition import DimensionDefinition
 
@@ -72,7 +75,8 @@ class Dimension(PydanticBaseModel):
             raise ValueError(
                 f"Dimension data for {definition.name} must have only one row or column."
             )
-        data = data.flatten().tolist()
+        if data.ndim != 1:
+            data = data.flatten()
         # delete header for items if present
         if data[0] == definition.name:
             data = data[1:]

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -1,7 +1,8 @@
-from pydantic_core import ValidationError
+import pandas as pd
 import pytest
+from pydantic_core import ValidationError
 
-from flodym import Dimension, DimensionSet
+from flodym import Dimension, DimensionDefinition, DimensionSet
 
 
 def test_validate_dimension_set():
@@ -608,3 +609,14 @@ def test_copy_dimension_set():
     # Ensure the contained Dimension objects remain the same
     for o_dim, c_dim in zip(original, copied):
         assert o_dim is c_dim
+
+def test_from_np_with_stringarray():
+    """Test that from_np() can handle a pandas array of strings."""
+    string_array = pd.array(["a", "b", "c"], dtype="string")
+    definition = DimensionDefinition(name='Region', letter='r', dtype=str)
+    dim = Dimension.from_np(string_array, definition)
+
+    # Verify the items are correctly set
+    assert dim.items == ["a", "b", "c"]
+    assert dim.name == "Region"
+    assert dim.letter == "r"

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -610,10 +610,11 @@ def test_copy_dimension_set():
     for o_dim, c_dim in zip(original, copied):
         assert o_dim is c_dim
 
+
 def test_from_np_with_stringarray():
     """Test that from_np() can handle a pandas array of strings."""
     string_array = pd.array(["a", "b", "c"], dtype="string")
-    definition = DimensionDefinition(name='Region', letter='r', dtype=str)
+    definition = DimensionDefinition(name="Region", letter="r", dtype=str)
     dim = Dimension.from_np(string_array, definition)
 
     # Verify the items are correctly set


### PR DESCRIPTION
## Purpose of this PR

Calling `Dimensions.from_np` with a 1-dim string array (from say pandas) resulted in an array since `StringArray` dosen't have a `flatten` method. Added a quick check for such 1-dim arrays.

Also removed the `tolist` call, since further below the data is anyway converted into a list of `dtype` items. (But maybe this call had some other usage that I don't see?)

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix
- [ ] Refactoring
- [ ] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [ ] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
