### PR TITLE
fix: add scalar value handling in DataFrameToFlodymDataConverter

### DIFF
--- a/flodym/_df_to_flodym_array.py
+++ b/flodym/_df_to_flodym_array.py
@@ -233,7 +233,7 @@ class DataFrameToFlodymDataConverter:
                 raise ValueError(
                     "FlodymArray has no dimensions, but the DataFrame has no rows. Expected exactly one row."
                 )
-            if len(self.df) > 1 and not self.allow_extra_values:
+            if len(self.df) > 1:
                 raise ValueError(
                     f"FlodymArray has no dimensions, but the DataFrame has {len(self.df)} rows. Expected exactly one row."
                 )

--- a/flodym/_df_to_flodym_array.py
+++ b/flodym/_df_to_flodym_array.py
@@ -239,7 +239,6 @@ class DataFrameToFlodymDataConverter:
                 )
             return np.array(self.df[self.format.value_column].values[0])
 
-
         # check for double entries in the index columns
         indices = self.df[list(self.flodym_array.dims.names)]
         if indices.duplicated().any():

--- a/flodym/_df_to_flodym_array.py
+++ b/flodym/_df_to_flodym_array.py
@@ -1,10 +1,11 @@
-import sys
+import itertools
 import logging
+import sys
+from typing import TYPE_CHECKING, Iterable, Literal, Optional
+
 import numpy as np
 import pandas as pd
-from typing import Literal, Optional, TYPE_CHECKING, Iterable
 from pydantic import BaseModel as PydanticBaseModel
-import itertools
 
 from .dimensions import Dimension
 
@@ -224,11 +225,26 @@ class DataFrameToFlodymDataConverter:
         self.df = self.df[list(self.flodym_array.dims.names) + [self.format.value_column]]
 
     def _check_data_complete(self):
+        # Special handling of the scalar case: If the FlodymArray has no dimensions, we usually expect a single value in the df.
+        if self.flodym_array.dims.ndim == 0:
+            if len(self.df) == 0:
+                if self.allow_missing_values:
+                    return np.array(0.0)
+                raise ValueError(
+                    "FlodymArray has no dimensions, but the DataFrame has no rows. Expected exactly one row."
+                )
+            if len(self.df) > 1 and not self.allow_extra_values:
+                raise ValueError(
+                    f"FlodymArray has no dimensions, but the DataFrame has {len(self.df)} rows. Expected exactly one row."
+                )
+            return np.array(self.df[self.format.value_column].values[0])
+
+
         # check for double entries in the index columns
         indices = self.df[list(self.flodym_array.dims.names)]
         if indices.duplicated().any():
             raise ValueError(
-                f"The following index combinations occur more than once in the data: ",
+                "The following index combinations occur more than once in the data: ",
                 indices[indices.duplicated()],
             )
 

--- a/tests/test_flodym_arrays.py
+++ b/tests/test_flodym_arrays.py
@@ -1,11 +1,16 @@
-import numpy as np
-import pandas as pd
-from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
-from pydantic_core import ValidationError
-import pytest
 from copy import deepcopy
 
-from flodym import FlodymArray, DimensionSet, Dimension
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+)
+from pydantic_core import ValidationError
+
+from flodym import Dimension, DimensionSet, FlodymArray
 
 places = Dimension(name="place", letter="p", items=["Earth", "Sun", "Moon", "Venus"])
 local_places = Dimension(name="local place", letter="l", items=["Earth"])
@@ -306,6 +311,17 @@ def test_from_df_does_not_strip_whitespace_when_disabled():
 
     with pytest.raises(ValueError, match="More than one value columns"):
         FlodymArray.from_df(dims=dims_subset, df=df, strip_whitespace=False)
+
+
+def test_from_df_scalar_value():
+    scalar = DimensionSet.empty()
+    df = pd.DataFrame({"value": [7.5]})
+
+    result = FlodymArray.from_df(dims=scalar, df=df)
+
+    assert result.dims.ndim == 0
+    assert result.values.shape == ()
+    assert result.values.item() == 7.5
 
 
 class TestFlodymArrayFull:


### PR DESCRIPTION
## Purpose of this PR

Fixes https://github.com/pik-piam/remind-mfa/issues/148.

That error was a result of NumPy expecting a scalar on the right-hand not a lenghth-1 array for 0-dim arrays. This is demonstrated in the following snippet:
```shell
>>> import numpy as np
>>> values = np.zeros(())
>>> values[()] = np.array([0.912514])
TypeError: only 0-dimensional arrays can be converted to Python scalars

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    values[()] = np.array([0.912514])
    ~~~~~~^^^^
ValueError: setting an array element with a sequence.
>>> values[()] = np.array(0.912514)
```
(see added test that essentially translated to this sequence of commands, and failed with the same error)

To fix this, I added early special handling for the scalar case. This was easier than trying to also make the `allow_extra_values/allow_missing_values` handle the scalar case correctly (the loops `for dim in self.flodym_array.dims` are empty in that case).

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix
- [ ] Refactoring
- [ ] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [ ] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
