### PR TITLE
chore: update GitHub Actions workflow to use uv

### DIFF
--- a/.github/workflows/main_actions.yml
+++ b/.github/workflows/main_actions.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install
-      run: uv sync --locked 
+      run: uv sync --locked
 
     - name: Run tests
       run: uv run pytest

--- a/.github/workflows/main_actions.yml
+++ b/.github/workflows/main_actions.yml
@@ -14,17 +14,30 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    name: Test on Python ${{ matrix.python-version }} (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
-        python-version: "3.12"
-    - name: Install dependencies and run tests
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[tests]"
-        python -m pytest
+        enable-cache: true
+        version: "0.11.28"
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      run: uv sync --locked 
+
+    - name: Run tests
+      run: uv run pytest


### PR DESCRIPTION
## Purpose of this PR

As a follow-up of the recent uv PRs, the github action workflow is now also using uv.

Also expanded the testing to all supported os/python versions. Since the tests run so fast and in parallel, this shouldn't have a negative effect for PR reviews.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix
- [ ] Refactoring
- [ ] New feature
- [ ] Minor change
- [ ] Major change


## Checklist:

- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
- [ ] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
