### PR TITLE
chore: Add pytest configuration for setting pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["flodym", "flodym.export"]
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Purpose of this PR
I noticed that running `uv run pytest` fails. This PR fixes it by adding the repo root to sys.path such that the notebook testing now works. This is a non-issue for github actions because it runs `python -m pytest`, which adds the cwd.
Let me know if this is something you don't like to change. Not sure what undesired implications this might have.

## Checklist:

- [ ] I have used the [Conventional Commits](https://www.conventionalcommits.org/) format for my PR title (and commit messages)
- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
