### PR TITLE
chore: update `uv.lock` file after version increment

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
     {
       "path": "uv.lock",
       "type": "toml",
-      "jsonpath": "$.package[?(@.name.value=='my-package')].version"
+      "jsonpath": "$.package[?(@.name.value=='flodym')].version"
     }
   ]
 }


### PR DESCRIPTION
## Purpose of this PR

The tests in the release PR https://github.com/pik-piam/flodym/pull/170 are still failing since the uv file was not updated, due to a stupid mistake on my side (forgot to replace `my-package` by `flodym`). Should be fixed now.

## Checklist:

- [x] I have used the [Conventional Commits](https://www.conventionalcommits.org/) format for my PR title (and commit messages)
- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
