### PR TITLE
chore: fix (random) test failures due to tkinter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     """
     Use non-interactive matplotlib backend on Windows to avoid error
     `_tkinter.TclError: Can't find a usable init.tcl`
-    
+
     https://github.com/matplotlib/matplotlib/issues/28957
     https://github.com/astral-sh/uv/issues/7036
     https://github.com/python/cpython/issues/125235

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import sys
+
+import matplotlib
+import pytest
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """
+    Use non-interactive matplotlib backend on Windows to avoid error
+    `_tkinter.TclError: Can't find a usable init.tcl`
+    
+    https://github.com/matplotlib/matplotlib/issues/28957
+    https://github.com/astral-sh/uv/issues/7036
+    https://github.com/python/cpython/issues/125235
+    https://github.com/actions/setup-python/issues/1102
+    """
+    if sys.platform.startswith("win"):
+        matplotlib.use("Agg")


### PR DESCRIPTION
## Purpose of this PR

The CI sometimes fails with a random `_tkinter.TclError: Can't find a usable init.tcl` error (eg https://github.com/pik-piam/flodym/actions/runs/29918180821/job/88916866941) and if I remember correctly @bennet21 experienced the same issue locally.

Should hopefully be fixed by changing the matplot backend at the begninning of the pytest session.

## Checklist:

- [x] I have used the [Conventional Commits](https://www.conventionalcommits.org/) format for my PR title (and commit messages)
- [ ] I have updated the in-code documentation of all changed classes and functions
- [x] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
