### PR TITLE
chore: only run release PR job in main repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   release-pr:
     name: Create Release PR
+    if: github.repository_owner == 'pik-piam'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Purpose of this PR

@bennet21 got errors in his fork as the "create release PR" job was running there as well (and then failed due to missing GH token). With this change, the job runs only in the main repo.

(It's again one of these CI changes that is impossible to check.)

## Checklist:

- [x] I have used the [Conventional Commits](https://www.conventionalcommits.org/) format for my PR title (and commit messages)
- [ ] I have updated the in-code documentation of all changed classes and functions
- [ ] I have added in-code documentation and type hints to all new classes and functions
- [ ] I have adapted the howtos
- [ ] I have adapted the examples
